### PR TITLE
Bugfix: slow load and split & disable re-rank when retrieved docs is empty

### DIFF
--- a/modules/LLMService.py
+++ b/modules/LLMService.py
@@ -64,11 +64,8 @@ class LLMService:
                 docs = DirectoryLoader(docs_dir, glob=self.cfg['create_docs']['glob'], show_progress=True).load()
                 docs = self.text_splitter.split_documents(docs)
             else:
-                logger.info('Uploading single file.')
-                docs = UnstructuredFileLoader(docs_dir, mode="elements", strategy="fast").load()
-                logger.info('Uploading single file. load')
-                docs = self.text_splitter.split_documents(docs)
-                logger.info('Uploading single file. text_splitter')
+                loader = UnstructuredFileLoader(docs_dir, mode="elements")
+                docs = loader.load_and_split(text_splitter=self.text_splitter)
 
             start_time = time.time()
             logger.info('Uploading custom knowledge.', start_time)

--- a/modules/LLMService.py
+++ b/modules/LLMService.py
@@ -64,8 +64,11 @@ class LLMService:
                 docs = DirectoryLoader(docs_dir, glob=self.cfg['create_docs']['glob'], show_progress=True).load()
                 docs = self.text_splitter.split_documents(docs)
             else:
-                loader = UnstructuredFileLoader(docs_dir, mode="elements")
-                docs = loader.load_and_split(text_splitter=self.text_splitter)
+                logger.info('Uploading single file.')
+                docs = UnstructuredFileLoader(docs_dir, mode="elements", strategy="fast").load()
+                logger.info('Uploading single file. load')
+                docs = self.text_splitter.split_documents(docs)
+                logger.info('Uploading single file. text_splitter')
 
             start_time = time.time()
             logger.info('Uploading custom knowledge.', start_time)

--- a/modules/VectorDB.py
+++ b/modules/VectorDB.py
@@ -415,7 +415,7 @@ class VectorDB:
             docs = self.filter_docs_by_thresh(docs, score_threshold)
 
         logger.info('[INFO] docs:\n', docs)
-        if model_name != 'No Re-Rank' and len(docs) > 0:
+        if model_name != 'No Re-Rank' and len(docs) > 1:
             docs = self.rerank_docs(query, docs, model_name)
 
         if len(docs) > topk:

--- a/modules/VectorDB.py
+++ b/modules/VectorDB.py
@@ -415,7 +415,7 @@ class VectorDB:
             docs = self.filter_docs_by_thresh(docs, score_threshold)
 
         logger.info('[INFO] docs:\n', docs)
-        if model_name != 'No Re-Rank':
+        if model_name != 'No Re-Rank' and len(docs) > 0:
             docs = self.rerank_docs(query, docs, model_name)
 
         if len(docs) > topk:

--- a/webui.py
+++ b/webui.py
@@ -12,6 +12,7 @@ from args import parse_args
 from modules.UI import *
 import sys
 from loguru import logger
+os.environ['SCARF_NO_ANALYTICS'] = 'true'
 
 _global_args = parse_args()
 service = LLMService()

--- a/webui.py
+++ b/webui.py
@@ -12,14 +12,21 @@ from args import parse_args
 from modules.UI import *
 import sys
 from loguru import logger
-os.environ['SCARF_NO_ANALYTICS'] = 'true'
+
+# Disable unstructured analytics tracking to mitigate timeout issues during PAI-EAS service.
+# This is achieved by setting an environment variable that the unstructured library recognizes.
+# By doing this, we prevent the library's internal function `scarf_analytics()` from making
+# network requests to "https://packages.unstructured.io", which was causing timeouts.
+
+os.environ["SCARF_NO_ANALYTICS"] = "true"
+
 
 _global_args = parse_args()
 service = LLMService()
 
 with open(_global_args.config) as f:
     _global_cfg = json.load(f)
-    
+
 class Query(BaseModel):
     question: str
     topk: int | None = None
@@ -33,7 +40,7 @@ class LLMQuery(BaseModel):
     topk: int | None = None
     topp: float | None = 0.8
     temperature: float | None = 0.7
-    
+
 class VectorQuery(BaseModel):
     question: str
     vector_topk: int | None = 3
@@ -57,7 +64,7 @@ def configure_cors_middleware(app):
     }
 
     app.add_middleware(CORSMiddleware, **cors_options)
-    
+
 def add_general_url(
     app
 ):    
@@ -142,7 +149,7 @@ def get_environment_params(_global_cfg):
         _global_cfg['MilvusCfg']['USER'] = os_env_params['MILVUS_USER']
         _global_cfg['MilvusCfg']['PASSWORD'] = os_env_params['MILVUS_PASSWORD']
         _global_cfg['MilvusCfg']['DROP'] = os_env_params['MILVUS_DROP']
-    
+
 def start_webui():
     global app
     get_environment_params(_global_cfg)
@@ -161,7 +168,7 @@ def start_webui():
     
     logger.info("Adding fast api url...")
     add_general_url(app)
-    
+
 if __name__ == "__main__":
     logger.remove()
     logger.add(sys.stderr, level=_global_args.log_level)


### PR DESCRIPTION
Bugfix：
1. 解决EAS上首次调用UnstructuredFileLoader需要等待5min的问题：系python包 unstructured/utils.py中引入默认加载trace分析(scarf_analytics)的逻辑，会从https://packages.unstructured.io/下载文件，而EAS上无法访问该网站，导致等待时间很长。
2. 解决当检索没有返回内容（Similarity Distance Threshold设置过小时）时，调用re-rank会报错的问题。