### PR TITLE
Add client default timeout limitation and support UI interactive

### DIFF
--- a/src/pai_rag/app/web/rag_client.py
+++ b/src/pai_rag/app/web/rag_client.py
@@ -8,6 +8,8 @@ import os
 import mimetypes
 from pai_rag.app.web.view_model import ViewModel
 
+DEFAULT_CLIENT_TIME_OUT = 60
+
 
 class dotdict(dict):
     """dot.notation access to dictionary attributes"""
@@ -62,7 +64,7 @@ class RagWebClient:
 
     def query(self, text: str, session_id: str = None):
         q = dict(question=text, session_id=session_id)
-        r = requests.post(self.query_url, json=q)
+        r = requests.post(self.query_url, json=q, timeout=DEFAULT_CLIENT_TIME_OUT)
         r.raise_for_status()
         response = dotdict(json.loads(r.text))
         referenced_docs = ""
@@ -88,7 +90,7 @@ class RagWebClient:
             session_id=session_id,
         )
 
-        r = requests.post(self.llm_url, json=q)
+        r = requests.post(self.llm_url, json=q, timeout=DEFAULT_CLIENT_TIME_OUT)
         r.raise_for_status()
         response = dotdict(json.loads(r.text))
 
@@ -96,7 +98,7 @@ class RagWebClient:
 
     def query_vector(self, text: str):
         q = dict(question=text)
-        r = requests.post(self.retrieval_url, json=q)
+        r = requests.post(self.retrieval_url, json=q, timeout=DEFAULT_CLIENT_TIME_OUT)
         r.raise_for_status()
         response = dotdict(json.loads(r.text))
         formatted_text = "<tr><th>Document</th><th>Score</th><th>Text</th></tr>\n"
@@ -122,8 +124,7 @@ class RagWebClient:
 
         try:
             r = requests.post(
-                self.load_data_url,
-                files=files,
+                self.load_data_url, files=files, timeout=DEFAULT_CLIENT_TIME_OUT
             )
             r.raise_for_status()
         except:
@@ -136,7 +137,7 @@ class RagWebClient:
         return response
 
     async def get_knowledge_state(self, task_id: str):
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=DEFAULT_CLIENT_TIME_OUT) as client:
             r = await client.get(self.get_load_state_url, params={"task_id": task_id})
             r.raise_for_status()
             response = dotdict(json.loads(r.text))
@@ -148,12 +149,14 @@ class RagWebClient:
         view_model.update(update_dict)
         new_config = view_model.to_app_config()
 
-        r = requests.patch(self.config_url, json=new_config)
+        r = requests.patch(
+            self.config_url, json=new_config, timeout=DEFAULT_CLIENT_TIME_OUT
+        )
         r.raise_for_status()
         return
 
     def get_config(self):
-        r = requests.get(self.config_url)
+        r = requests.get(self.config_url, timeout=DEFAULT_CLIENT_TIME_OUT)
         r.raise_for_status()
         response = dotdict(json.loads(r.text))
         print(response)
@@ -161,20 +164,26 @@ class RagWebClient:
 
     def evaluate_for_generate_qa(self, overwrite):
         r = requests.post(
-            self.get_evaluate_generate_url, params={"overwrite": overwrite}
+            self.get_evaluate_generate_url,
+            params={"overwrite": overwrite},
+            timeout=DEFAULT_CLIENT_TIME_OUT,
         )
         r.raise_for_status()
         response = dotdict(json.loads(r.text))
         return response
 
     def evaluate_for_retrieval_stage(self):
-        r = requests.post(self.get_evaluate_retrieval_url)
+        r = requests.post(
+            self.get_evaluate_retrieval_url, timeout=DEFAULT_CLIENT_TIME_OUT
+        )
         r.raise_for_status()
         response = dotdict(json.loads(r.text))
         return response
 
     def evaluate_for_response_stage(self):
-        r = requests.post(self.get_evaluate_response_url)
+        r = requests.post(
+            self.get_evaluate_response_url, timeout=DEFAULT_CLIENT_TIME_OUT
+        )
         r.raise_for_status()
         response = dotdict(json.loads(r.text))
         print("evaluate_for_response_stage response", response)

--- a/src/pai_rag/app/web/tabs/settings_tab.py
+++ b/src/pai_rag/app/web/tabs/settings_tab.py
@@ -12,8 +12,11 @@ from pai_rag.app.web.rag_client import rag_client
 from pai_rag.app.web.utils import components_to_dict
 from pai_rag.app.web.tabs.vector_db_panel import create_vector_db_panel
 import logging
+import os
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_IS_INTERACTIVE = os.environ.get("PAIRAG_RAG__LLM__interactive", "true")
 
 
 def connect_vector_db(input_elements: List[Any]):
@@ -39,6 +42,7 @@ def create_setting_tab() -> Dict[str, Any]:
                     EMBEDDING_API_KEY_DICT.keys(),
                     label="Embedding Type",
                     elem_id="embed_source",
+                    interactive=DEFAULT_IS_INTERACTIVE.lower() != "false",
                 )
                 embed_model = gr.Dropdown(
                     EMBEDDING_DIM_DICT.keys(),
@@ -88,6 +92,7 @@ def create_setting_tab() -> Dict[str, Any]:
                     ["PaiEas", "OpenAI", "DashScope"],
                     label="LLM Model Source",
                     elem_id="llm",
+                    interactive=DEFAULT_IS_INTERACTIVE.lower() != "false",
                 )
                 with gr.Column(visible=(llm == "PaiEas")) as eas_col:
                     llm_eas_url = gr.Textbox(

--- a/src/pai_rag/app/web/tabs/settings_tab.py
+++ b/src/pai_rag/app/web/tabs/settings_tab.py
@@ -16,7 +16,7 @@ import os
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_IS_INTERACTIVE = os.environ.get("PAIRAG_RAG__LLM__interactive", "true")
+DEFAULT_IS_INTERACTIVE = os.environ.get("PAIRAG_RAG__SETTING__interactive", "true")
 
 
 def connect_vector_db(input_elements: List[Any]):

--- a/src/pai_rag/app/web/tabs/vector_db_panel.py
+++ b/src/pai_rag/app/web/tabs/vector_db_panel.py
@@ -1,6 +1,9 @@
 import gradio as gr
 from typing import Any, Set, Callable, Dict
 from pai_rag.app.web.utils import components_to_dict
+import os
+
+DEFAULT_IS_INTERACTIVE = os.environ.get("PAIRAG_RAG__SETTING__interactive", "true")
 
 
 def create_vector_db_panel(
@@ -15,6 +18,7 @@ def create_vector_db_panel(
                 ["Hologres", "Milvus", "ElasticSearch", "AnalyticDB", "FAISS"],
                 label="Which VectorStore do you want to use?",
                 elem_id="vectordb_type",
+                interactive=DEFAULT_IS_INTERACTIVE.lower() != "false",
             )
             # Adb
             with gr.Column(visible=(vectordb_type == "AnalyticDB")) as adb_col:


### PR DESCRIPTION
1. rag_client 添加默认超时时长：60s
2. 允许在EAS部署环境下设置LLM/embedding source为不可改变状态