### PR TITLE
Fix ui issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ It supports uploading local files through API and supports specifying different 
 - upload_data
 
 ```bash
-curl -X 'POST' http://127.0.0.1:8000/service/upload_data -H 'Content-Type: multipart/form-data' -F 'file=@local_path/PAI.txt' -F 'faiss_path=localdata/storage'
+curl -X 'POST' http://127.0.0.1:8000/service/upload_data -H 'Content-Type: multipart/form-data' -F 'files=@local_path/PAI.txt' -F 'faiss_path=localdata/storage'
 
 # Return: {"task_id": "2c1e557733764fdb9fefa063538914da"}
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -184,7 +184,7 @@ docker run --network host -d mybigpai-public-registry.cn-beijing.cr.aliyuncs.com
 - 上传（upload_data）
 
 ```bash
-curl -X 'POST' http://127.0.0.1:8000/service/upload_data -H 'Content-Type: multipart/form-data' -F 'file=@local_path/PAI.txt' -F 'faiss_path=localdata/storage'
+curl -X 'POST' http://127.0.0.1:8000/service/upload_data -H 'Content-Type: multipart/form-data' -F 'files=@local_path/PAI.txt' -F 'faiss_path=localdata/storage'
 
 # Return: {"task_id": "2c1e557733764fdb9fefa063538914da"}
 ```

--- a/src/pai_rag/app/web/tabs/settings_tab.py
+++ b/src/pai_rag/app/web/tabs/settings_tab.py
@@ -63,21 +63,21 @@ def create_setting_tab() -> Dict[str, Any]:
                         else DEFAULT_EMBED_SIZE,
                     }
 
-                def change_emb_model(model):
+                def change_emb_model(source, model):
                     return {
                         embed_dim: EMBEDDING_DIM_DICT.get(model, DEFAULT_EMBED_SIZE)
-                        if embed_source == "HuggingFace"
+                        if source == "HuggingFace"
                         else DEFAULT_EMBED_SIZE,
                     }
 
-                embed_source.change(
+                embed_source.input(
                     fn=change_emb_source,
                     inputs=embed_source,
                     outputs=[embed_model, embed_dim],
                 )
-                embed_model.change(
+                embed_model.input(
                     fn=change_emb_model,
-                    inputs=embed_model,
+                    inputs=[embed_source, embed_model],
                     outputs=[embed_dim],
                 )
             components.extend([embed_source, embed_dim, embed_model, embed_batch_size])
@@ -132,7 +132,7 @@ def create_setting_tab() -> Dict[str, Any]:
                         ),
                     }
 
-                llm.change(
+                llm.input(
                     fn=change_llm,
                     inputs=llm,
                     outputs=[eas_col, api_llm_col, llm_api_model_name],

--- a/src/pai_rag/app/web/webui.py
+++ b/src/pai_rag/app/web/webui.py
@@ -29,7 +29,7 @@ def resume_ui():
             elem_attr = component_settings[elem_id]
             elem = elem_manager.get_elem_by_id(elem_id=elem_id)
             # For gradio version 3.41.0, we can remove .value for latest gradio here.
-            outputs[elem] = elem.__class__(**elem_attr).value
+            outputs[elem] = gr.update(**elem_attr)
             # if elem_id == "qa_dataset_file":
             #     outputs[elem] = elem_attr["value"]
             # else:


### PR DESCRIPTION
- 修复UI切换dropdown之后对应选项一直显示第一个的bug，如切换embedding, llm，对应model_name永远是第一个。原因是目前设置了session，当session加载时会更新各组件值，dropdown change事件会capture这个行为，并触发change事件，重新覆盖关联的组件为默认值。解决方案是使用input监听，只有在用户出发的change事件才会覆盖关联组件。
- 修复upload-data说明里的参数问题