### PR TITLE
[instrumentation] input & output format to json

### DIFF
--- a/src/pai_rag/app/api/models.py
+++ b/src/pai_rag/app/api/models.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pydantic import BaseModel
-from typing import Any, List, Dict, Optional
+from typing import Any, List, Dict, Optional, AsyncGenerator, Generator
 from llama_index.core.schema import QueryBundle
 from llama_index.core.base.llms.types import ChatMessage
 from dataclasses import dataclass
@@ -125,3 +125,15 @@ class ChatResponseWrapper(BaseModel):
     response: Any
     additional_kwargs: Dict[str, Any] = {}
     source_nodes: List[NodeWithScore] = []
+
+    def model_dump_json(self, exclude=None, **kwargs) -> str:
+        if exclude is None:
+            exclude = set()
+        elif isinstance(exclude, dict):
+            exclude = {k for k, v in exclude.items() if v}
+
+        # to compatible with arize instrumentation
+        if isinstance(self.response, (Generator, AsyncGenerator)):
+            exclude.add("response")
+
+        return super().model_dump_json(exclude=exclude, **kwargs)

--- a/src/pai_rag/integrations/query_engine/pai_retriever_query_engine.py
+++ b/src/pai_rag/integrations/query_engine/pai_retriever_query_engine.py
@@ -157,7 +157,6 @@ class PaiRetrieverQueryEngine(RetrieverQueryEngine):
         if isinstance(query_bundle, str):
             query_bundle = PaiQueryBundle(query_bundle)
         query_result = await self._aquery(query_bundle)
-        print("+++ query engine returns")
 
         if not query_bundle.stream:
             dispatcher.event(

--- a/src/pai_rag/integrations/trace/base.py
+++ b/src/pai_rag/integrations/trace/base.py
@@ -2,6 +2,8 @@ import socket
 from functools import wraps
 from typing import Callable, AsyncGenerator
 from loguru import logger
+from pydantic.v1 import json as pydantic_v1_json
+from pydantic import json as pydantic_json
 
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
@@ -67,3 +69,11 @@ def use_current_span(span: Span):
         return wrapper
 
     return decorator
+
+
+# arize instrumentation uses: pydantic.v1.json.pydantic_encoder
+# but pydantic.v1.json.pydantic_encoder explicitly check v1
+# this caused llama-index obj fails pydantic/v1/json.py#L77
+# from pydantic.v1.main import BaseModel
+# if isinstance(obj, BaseModel):
+pydantic_v1_json.pydantic_encoder = pydantic_json.pydantic_encoder


### PR DESCRIPTION
1. ChatMessage在arize process_input调用pandantic.v1.json.pandantic_encoder时Exception，导致使用了repr来序列化。改用另一个pandantic.json.pydantic_encoder
2. ChatResponseWrapper在arize process_output序列化response是，由于类型为AsyncGenerator报错，参考arize逻辑，跳过该字段。