### PR TITLE
Enable span tracing on MiaobiNewsToo alist_topics calls.

### DIFF
--- a/src/pai_rag/extensions/news/miaobi_news.py
+++ b/src/pai_rag/extensions/news/miaobi_news.py
@@ -225,6 +225,7 @@ class MiaobiNewsTool(LLM):
         )
         return sorted_hot_topics
 
+    @dispatcher.span
     async def alist_topics(
         self,
         query_str: str,
@@ -263,7 +264,15 @@ class MiaobiNewsTool(LLM):
                     content=content,
                 )
             ]
-
+            # store hot topics in span output
+            span_id = active_span_id.get()
+            dispatcher.event(
+                QueryEndEvent(
+                    response=Response(response=str(hot_topics), source_nodes=[]),
+                    query="",
+                    span_id=span_id,
+                )
+            )
             response = await self.llm.achat(messages)
             response.additional_kwargs["news_articles"] = hot_topics
             return ChatResponseWrapper(response=response)


### PR DESCRIPTION
MiaobiNews alist_topics方法
1. 加dispatcher.span decorator，产生span对象
2. 创建并发送QueryEndEvent，_Span.process_event里会解析出news topic list内容并写入span output里。
![image](https://github.com/user-attachments/assets/1b702e0e-0241-438e-bcfb-e89a2504210e)
