### PR TITLE
Set correct span hierarchical order in MiaobiNews astream_list_topics calls.

### DIFF
--- a/src/pai_rag/extensions/news/miaobi_news.py
+++ b/src/pai_rag/extensions/news/miaobi_news.py
@@ -37,6 +37,8 @@ from alibabacloud_tea_openapi_sse import models as open_api_models
 from alibabacloud_tea_util_sse import models as open_api_util_models
 import json
 
+from openinference.instrumentation.llama_index import get_current_span
+from pai_rag.integrations.trace.base import use_current_span
 from pydantic import BaseModel
 from loguru import logger
 
@@ -291,6 +293,10 @@ class MiaobiNewsTool(LLM):
             news_topics = kwargs.get("news_topics", [])
             span_id = active_span_id.get()
 
+            # use use_current_span decorator to keep miaobinews span
+            # as the parent of the self.llm's span,
+            # when self.llm.astream_chat executes in this gen()
+            @use_current_span(get_current_span())
             async def gen() -> ChatResponseAsyncGen:
                 yield ChatResponse(
                     message=ChatMessage(


### PR DESCRIPTION
MiaobiNewsTool的astream_list_topics内部的gen()方法里，还会调用self.llm.astream_chat()。因为astream_list_topics的span会在self.llm.astream_chat()的span开始前就结束，导致self.llm的span丢失了miaobi这个 parent span的信息，导致self.llm span错误的成为miaobi span的兄弟节点，而不是后代节点。

加上use_current_span decorator修复这个问题。

修复前效果
![image](https://github.com/user-attachments/assets/83167854-32ae-461c-b9ba-b83871835c1c)

修复后效果
![image](https://github.com/user-attachments/assets/bca14940-c214-4144-a816-c150bb29e53c)
