### PR TITLE
Enable span tracing in news achat_llm and astream_chat_llm calls.

### DIFF
--- a/src/pai_rag/extensions/news/miaobi_news.py
+++ b/src/pai_rag/extensions/news/miaobi_news.py
@@ -530,59 +530,64 @@ class MiaobiNewsTool(LLM):
 
         return gen()
 
+    def _get_news_role_texts(self) -> List[str]:
+        default_news_role_response = DEFAULT_NEWS_ROLE.format(
+            domain_list="/".join(self.config.domain_list),
+            news_role=self.config.news_role,
+        )
+        lines = []
+        for line in default_news_role_response.split("\n"):
+            if line.strip():
+                lines.append(line)
+        return lines
+
+    @dispatcher.span
     async def achat_llm(
         self,
         query_str: str,
-    ):
-        stream_response_wrapper = await self.astream_chat_llm(query_str)
-        message_content = ""
-        additional_kwargs = {}
-        async for response in stream_response_wrapper.response:
-            message_content += response.delta
-            additional_kwargs.update(response.additional_kwargs)
+    ) -> ChatResponseWrapper:
+        news_role_text = ""
+        for line in self._get_news_role_texts():
+            news_role_text += line
 
         return ChatResponseWrapper(
             response=ChatResponse(
                 message=ChatMessage(
                     role=MessageRole.ASSISTANT,
-                    content=message_content,
+                    content=news_role_text,
                 ),
-                additional_kwargs=additional_kwargs,
-                source_nodes=stream_response_wrapper.source_nodes,
             )
         )
 
+    @dispatcher.span
     async def astream_chat_llm(
         self,
         query_str: str,
     ) -> ChatResponseWrapper:
-        logger.info(f"Chat news only llm with query {query_str}")
+        span_id = active_span_id.get()
+        logger.info(f"Chat news only llm with query {query_str}, span:{span_id}")
+        news_role_text = ""
+        lines = self._get_news_role_texts()
+        for line in lines:
+            news_role_text += line
+        # store role text in span output
+        dispatcher.event(
+            QueryEndEvent(
+                response=Response(response=news_role_text, source_nodes=[]),
+                query="",
+                span_id=span_id,
+            )
+        )
 
         async def gen() -> ChatResponseAsyncGen:
-            yield ChatResponse(
-                message=ChatMessage(
-                    role=MessageRole.ASSISTANT,
-                    content="",
-                ),
-                delta="",
-                additional_kwargs={"intent": ChatIntentType.CHAT_NEWS},
-            )
-            default_news_role_response = DEFAULT_NEWS_ROLE.format(
-                domain_list="/".join(self.config.domain_list),
-                news_role=self.config.news_role,
-            )
-            text_parts = default_news_role_response.split("\n")
-
-            # 逐个 yield 返回
-            for part in text_parts:
-                if part.strip():
-                    yield ChatResponse(
-                        message=ChatMessage(
-                            role=MessageRole.ASSISTANT,
-                            content=part,
-                        ),
-                        delta=part,
-                    )
+            for line in lines:
+                yield ChatResponse(
+                    message=ChatMessage(
+                        role=MessageRole.ASSISTANT,
+                        content=line,
+                    ),
+                    delta=line,
+                )
 
         return ChatResponseWrapper(response=gen())
 

--- a/src/pai_rag/extensions/news/miaobi_news.py
+++ b/src/pai_rag/extensions/news/miaobi_news.py
@@ -565,7 +565,7 @@ class MiaobiNewsTool(LLM):
         query_str: str,
     ) -> ChatResponseWrapper:
         span_id = active_span_id.get()
-        logger.info(f"Chat news only llm with query {query_str}, span:{span_id}")
+        logger.info(f"Chat news only llm with query {query_str}")
         news_role_text = ""
         lines = self._get_news_role_texts()
         for line in lines:


### PR DESCRIPTION
news achat_llm 和astream_chat_llm方法返回相同的固定内容，只是astream模拟了stream返回风格。
1. 解除了二者的调用依赖关系，数据部分做成独立方法，供二者调用，避免了一次生成2个spans的问题。
2. achat_llm的返回值可以直接被instrumentation framework解析出output内容
3. astream_chat_llm的返回值不能被解析，所以需要单独发送一个带output内容的事件，让framework解析。

效果：
![image](https://github.com/user-attachments/assets/8ce9bcd7-2254-40d1-849e-5cc10f151a6d)
![image](https://github.com/user-attachments/assets/7713db3a-8b4a-42a2-b88a-598bb608b433)
