### PR TITLE
Fix markdown parser & format UI

### DIFF
--- a/backend/rag/file/splitters/pai_markdown_parser.py
+++ b/backend/rag/file/splitters/pai_markdown_parser.py
@@ -158,15 +158,20 @@ class StructuredNodeParser(BaseModel):
 
         # 单个节点token数大于chunk_size，则需要将节点进行拆分。拆分元素里不会含有image。
         if not tree_node.children:
-            for chunk_text in self._cut(tree_node.content):
-                if title_stack:
-                    new_chunk_text = (
-                        f"{self._format_section_header(title_stack)} : {chunk_text}"
-                    )
-                else:
-                    new_chunk_text = chunk_text
-                node = self._create_text_node(new_chunk_text, doc_node, ref_doc)
+            if tree_node.category in ["html_table", "image_caption"]:
+                # 处理HTML表格和图片描述，不进行切割
+                node = self._create_text_node(tree_node.content, doc_node, ref_doc)
                 nodes_list.append(node)
+            else:
+                for chunk_text in self._cut(tree_node.content):
+                    if title_stack:
+                        new_chunk_text = (
+                            f"{self._format_section_header(title_stack)} : {chunk_text}"
+                        )
+                    else:
+                        new_chunk_text = chunk_text
+                    node = self._create_text_node(new_chunk_text, doc_node, ref_doc)
+                    nodes_list.append(node)
 
         nodes_groups = self._split_level_nodes(tree_node.children)
         for node_group in nodes_groups:

--- a/backend/rag/file/utils/markdown_utils.py
+++ b/backend/rag/file/utils/markdown_utils.py
@@ -202,9 +202,18 @@ class ASTTreeBuilder:
         if not content:
             return  # 忽略空段落
 
-        new_node = TreeNode(
-            level=self.stack[-1].level, category="paragraph", content=content
-        )
+        if content.startswith("<html><body><table>") and content.endswith("</table></body></html>"):
+            new_node = TreeNode(
+                level=self.stack[-1].level + 1, category="html_table", content=content
+            )
+        elif content.startswith("<img") and content.endswith("/>"):
+            new_node = TreeNode(
+                level=self.stack[-1].level + 1, category="image_caption", content=content
+            )
+        else:
+            new_node = TreeNode(
+                level=self.stack[-1].level, category="paragraph", content=content
+            )
         self.stack[-1].add_child(new_node)
 
     def handle_code_fence(self, node: CodeFence):

--- a/backend/rag/knowledgebase_tool.py
+++ b/backend/rag/knowledgebase_tool.py
@@ -140,7 +140,7 @@ class PaiKnowledgebaseClient:
 
             vector_store = self.create_vector_store_from_knowledgebase(knowledgebase, embed_model=embed_model)
             if old_chunk_ids:
-                vector_store.delete_nodes(node_ids=old_chunk_ids)
+                await vector_store.adelete_nodes(node_ids=old_chunk_ids)
                 logger.info(f"Removed {len(old_chunk_ids)} from vector store.")
 
             texts_to_embed = [f"{node.text}\n\nfile_name: {node.metadata['file_name']}" for node in nodes]
@@ -188,7 +188,7 @@ class PaiKnowledgebaseClient:
 
         knowledgebase = await knowledgebase_provider.aget_knowledgebase(kb_id)
         vector_store = self.create_vector_store_from_knowledgebase(knowledgebase)
-        vector_store.delete_nodes(node_ids=node_ids)
+        await vector_store.adelete_nodes(node_ids=node_ids)
         logger.info(
             f"Deleted {len(node_ids)} chunks from {kb_id} vector db successfully."
         )

--- a/frontend/app/knowledgebase/chunks/htmlRender.tsx
+++ b/frontend/app/knowledgebase/chunks/htmlRender.tsx
@@ -1,0 +1,150 @@
+// htmlRenderer.tsx
+import parse, { Element, HTMLReactParserOptions } from "html-react-parser";
+import React from "react"; // 确保导入 React
+
+// --- 1. 通用的 isHtmlContent 函数 ---
+// 检查文本是否包含 <html> 标签（无论是作为开头还是嵌入其中）
+const isHtmlContent = (text: string) => {
+  const trimmedText = text?.trim();
+  // 只要包含 <html> 就认为是包含 HTML 内容
+  return trimmedText?.includes("<html>");
+};
+
+// --- 2. 提取 <body> 内容的函数 (用于纯 HTML 文档) ---
+const extractBodyContent = (htmlString: string) => {
+  const bodyStart = htmlString.indexOf("<body");
+  const bodyEnd = htmlString.lastIndexOf("</body>");
+
+  if (bodyStart !== -1 && bodyEnd !== -1) {
+    const bodyOpenEnd = htmlString.indexOf(">", bodyStart);
+    if (bodyOpenEnd !== -1) {
+      return htmlString.substring(bodyOpenEnd + 1, bodyEnd).trim();
+    }
+  }
+  return htmlString; // Fallback
+};
+
+// --- 3. 提取所有 <html>...</html> 块的函数 (用于嵌入 HTML 的文本) ---
+const extractHtmlBlocks = (text: string): string[] => {
+  const htmlBlocks: string[] = [];
+  const prefix = "<html>";
+  const suffix = "</html>";
+  let startIndex = 0;
+
+  while (startIndex < text.length) {
+    const blockStart = text.indexOf(prefix, startIndex);
+    if (blockStart === -1) break; // No more <html> found
+
+    const blockEnd = text.indexOf(suffix, blockStart);
+    if (blockEnd === -1) break; // Unmatched <html>, stop processing
+
+    // Extract the full <html>...</html> block
+    const htmlBlock = text.substring(blockStart, blockEnd + suffix.length);
+    htmlBlocks.push(htmlBlock);
+
+    // Move the search start index past the end of the current block
+    startIndex = blockEnd + suffix.length;
+  }
+
+  return htmlBlocks;
+};
+
+// --- 4. 定义 HTMLReactParserOptions (为表格和单元格添加样式) ---
+const tableOptions: HTMLReactParserOptions = {
+  replace(domNode) {
+    // 处理 <table> 标签
+    if (domNode.type === "tag" && domNode.name === "table") {
+      const element = domNode as Element;
+      const existingTableClass =
+        element.attribs.className || element.attribs.class || "";
+      // 添加边框、边框合并、居中、上下边距
+      const tableBorderClasses =
+        "border border-collapse border-gray-500 mx-auto my-2";
+      const updatedTableClassName = existingTableClass
+        ? `${existingTableClass} ${tableBorderClasses}`
+        : tableBorderClasses;
+      element.attribs.className = updatedTableClassName;
+      delete element.attribs.class;
+      return undefined;
+    }
+
+    // 处理 <td> 和 <th> 标签
+    if (
+      domNode.type === "tag" &&
+      (domNode.name === "td" || domNode.name === "th")
+    ) {
+      const element = domNode as Element;
+      const existingCellClass =
+        element.attribs.className || element.attribs.class || "";
+      // 添加内边距和边框
+      const cellBorderClasses = "border border-gray-500 p-2";
+      const updatedCellClassName = existingCellClass
+        ? `${existingCellClass} ${cellBorderClasses}`
+        : cellBorderClasses;
+      element.attribs.className = updatedCellClassName;
+      delete element.attribs.class;
+      return undefined;
+    }
+
+    // 对于其他元素，使用默认行为
+    return undefined;
+  },
+};
+
+// --- 5. 主要的 HTML 渲染函数 ---
+export const htmlRender = (text: string) => {
+  const trimmedText = text.trim();
+
+  // 情况 1: chunk.text 本身就是一个完整的 HTML 文档
+  if (trimmedText.startsWith("<html>")) {
+    try {
+      // 提取 <body> 内容并解析
+      const bodyContent = extractBodyContent(trimmedText);
+      return parse(bodyContent, tableOptions);
+    } catch (error) {
+      console.error("Error parsing standalone HTML document:", error);
+      // 如果解析失败，回退到显示原始文本
+      return <pre>{text}</pre>;
+    }
+  }
+  // 情况 2: chunk.text 是包含 HTML 块的文本
+  else if (isHtmlContent(text)) {
+    try {
+      // 提取所有 <html>...</html> 块
+      const htmlBlocks = extractHtmlBlocks(text);
+
+      if (htmlBlocks.length > 0) {
+        // 对每个 HTML 块提取 <body> 内容并解析，然后将结果组合起来
+        return (
+          <>
+            {/* 渲染 HTML 块之前的部分文本 */}
+            {text.substring(0, text.indexOf("<html>"))}
+            {/* 渲染每个解析后的 HTML 块 */}
+            {htmlBlocks.map((htmlBlock, index) => {
+              const bodyContent = extractBodyContent(htmlBlock);
+              // 使用 React Fragment 包裹，以防 parse 返回多个根元素
+              // key 用于 React 列表渲染
+              return (
+                <React.Fragment key={index}>
+                  {parse(bodyContent, tableOptions)}
+                </React.Fragment>
+              );
+            })}
+            {/* 渲染最后一个 HTML 块之后的部分文本 */}
+            {text.substring(text.lastIndexOf("</html>") + "</html>".length)}
+          </>
+        );
+      } else {
+        return text;
+      }
+    } catch (error) {
+      console.error("Error parsing embedded HTML blocks:", error);
+      // 如果解析嵌入的 HTML 失败，回退到显示原始文本
+      return <pre>{text}</pre>;
+    }
+  }
+  // 情况 3: 不包含 HTML，按普通文本渲染
+  else {
+    return text;
+  }
+};

--- a/frontend/app/knowledgebase/chunks/page.tsx
+++ b/frontend/app/knowledgebase/chunks/page.tsx
@@ -30,7 +30,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import parse, { Element, HTMLReactParserOptions } from "html-react-parser";
+import { htmlRender } from "@/app/knowledgebase/chunks/htmlRender";
 
 interface KnowledgeBase {
   id: string;
@@ -218,153 +218,6 @@ export default function KnowledgeBaseFileChunksPage({
     setIsEditOpen(true);
   };
 
-  // --- 1. 通用的 isHtmlContent 函数 ---
-  // 检查文本是否包含 <html> 标签（无论是作为开头还是嵌入其中）
-  const isHtmlContent = (text: string) => {
-    const trimmedText = text?.trim();
-    // 只要包含 <html> 就认为是包含 HTML 内容
-    return trimmedText?.includes("<html>");
-  };
-
-  // --- 2. 提取 <body> 内容的函数 (用于纯 HTML 文档) ---
-  const extractBodyContent = (htmlString: string) => {
-    const bodyStart = htmlString.indexOf("<body");
-    const bodyEnd = htmlString.lastIndexOf("</body>");
-
-    if (bodyStart !== -1 && bodyEnd !== -1) {
-      const bodyOpenEnd = htmlString.indexOf(">", bodyStart);
-      if (bodyOpenEnd !== -1) {
-        return htmlString.substring(bodyOpenEnd + 1, bodyEnd).trim();
-      }
-    }
-    return htmlString; // Fallback
-  };
-
-  // --- 3. 提取所有 <html>...</html> 块的函数 (用于嵌入 HTML 的文本) ---
-  const extractHtmlBlocks = (text: string): string[] => {
-    const htmlBlocks: string[] = [];
-    const prefix = "<html>";
-    const suffix = "</html>";
-    let startIndex = 0;
-
-    while (startIndex < text.length) {
-      const blockStart = text.indexOf(prefix, startIndex);
-      if (blockStart === -1) break; // No more <html> found
-
-      const blockEnd = text.indexOf(suffix, blockStart);
-      if (blockEnd === -1) break; // Unmatched <html>, stop processing
-
-      // Extract the full <html>...</html> block
-      const htmlBlock = text.substring(blockStart, blockEnd + suffix.length);
-      htmlBlocks.push(htmlBlock);
-
-      // Move the search start index past the end of the current block
-      startIndex = blockEnd + suffix.length;
-    }
-
-    return htmlBlocks;
-  };
-
-  // --- 4. 定义 HTMLReactParserOptions (为表格和单元格添加样式) ---
-  const tableOptions: HTMLReactParserOptions = {
-    replace(domNode) {
-      // 处理 <table> 标签
-      if (domNode.type === "tag" && domNode.name === "table") {
-        const element = domNode as Element;
-        const existingTableClass =
-          element.attribs.className || element.attribs.class || "";
-        // 添加边框、边框合并、居中、上下边距
-        const tableBorderClasses =
-          "border border-collapse border-gray-500 mx-auto my-2";
-        const updatedTableClassName = existingTableClass
-          ? `${existingTableClass} ${tableBorderClasses}`
-          : tableBorderClasses;
-        element.attribs.className = updatedTableClassName;
-        delete element.attribs.class;
-        return undefined;
-      }
-
-      // 处理 <td> 和 <th> 标签
-      if (
-        domNode.type === "tag" &&
-        (domNode.name === "td" || domNode.name === "th")
-      ) {
-        const element = domNode as Element;
-        const existingCellClass =
-          element.attribs.className || element.attribs.class || "";
-        // 添加内边距和边框
-        const cellBorderClasses = "border border-gray-500 p-2";
-        const updatedCellClassName = existingCellClass
-          ? `${existingCellClass} ${cellBorderClasses}`
-          : cellBorderClasses;
-        element.attribs.className = updatedCellClassName;
-        delete element.attribs.class;
-        return undefined;
-      }
-
-      // 对于其他元素，使用默认行为
-      return undefined;
-    },
-  };
-
-  // --- 5. 主要的 HTML 渲染函数 ---
-  const renderHtmlContent = (text: string) => {
-    const trimmedText = text.trim();
-
-    // 情况 1: chunk.text 本身就是一个完整的 HTML 文档
-    if (trimmedText.startsWith("<html>")) {
-      try {
-        // 提取 <body> 内容并解析
-        const bodyContent = extractBodyContent(trimmedText);
-        return parse(bodyContent, tableOptions);
-      } catch (error) {
-        console.error("Error parsing standalone HTML document:", error);
-        // 如果解析失败，回退到显示原始文本
-        return <pre>{text}</pre>;
-      }
-    }
-    // 情况 2: chunk.text 是包含 HTML 块的文本
-    else if (isHtmlContent(text)) {
-      try {
-        // 提取所有 <html>...</html> 块
-        const htmlBlocks = extractHtmlBlocks(text);
-
-        if (htmlBlocks.length > 0) {
-          // 对每个 HTML 块提取 <body> 内容并解析，然后将结果组合起来
-          return (
-            <>
-              {/* 渲染 HTML 块之前的部分文本 */}
-              {text.substring(0, text.indexOf("<html>"))}
-              {/* 渲染每个解析后的 HTML 块 */}
-              {htmlBlocks.map((htmlBlock, index) => {
-                const bodyContent = extractBodyContent(htmlBlock);
-                // 使用 React Fragment 包裹，以防 parse 返回多个根元素
-                // key 用于 React 列表渲染
-                return (
-                  <React.Fragment key={index}>
-                    {parse(bodyContent, tableOptions)}
-                  </React.Fragment>
-                );
-              })}
-              {/* 渲染最后一个 HTML 块之后的部分文本 */}
-              {text.substring(text.lastIndexOf("</html>") + "</html>".length)}
-            </>
-          );
-        } else {
-          return text;
-        }
-      } catch (error) {
-        console.error("Error parsing embedded HTML blocks:", error);
-        // 如果解析嵌入的 HTML 失败，回退到显示原始文本
-        return <pre>{text}</pre>;
-      }
-    }
-    // 情况 3: 不包含 HTML，按普通文本渲染
-    else {
-      return text;
-    }
-  };
-
   const handleSaveEdit = async () => {
     if (!selectedChunk) return;
     selectedChunk.text = editText;
@@ -488,7 +341,7 @@ export default function KnowledgeBaseFileChunksPage({
                     </CardHeader>
                     <CardContent className="bg-gray-200/10 flex-grow overflow-y-auto overflow-x-auto pr-3 p-3 pb-2 mt-1 mb-1">
                       <div className="whitespace-pre-wrap break-words text-sm leading-relaxed whitespace-normal pr-2">
-                        {renderHtmlContent(chunk.text)}
+                        {htmlRender(chunk.text)}
                       </div>
                     </CardContent>
                     <CardFooter className="shrink-0 gap-2">

--- a/frontend/app/knowledgebase/chunks/page.tsx
+++ b/frontend/app/knowledgebase/chunks/page.tsx
@@ -19,7 +19,6 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { PhotoProvider, PhotoView } from "react-photo-view";
 import "react-photo-view/dist/react-photo-view.css";
 import { PaginationComponent } from "@/components/customized/pagination/pagination-component";
@@ -31,6 +30,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
+import parse, { Element, HTMLReactParserOptions } from "html-react-parser";
 
 interface KnowledgeBase {
   id: string;
@@ -218,6 +218,153 @@ export default function KnowledgeBaseFileChunksPage({
     setIsEditOpen(true);
   };
 
+  // --- 1. 通用的 isHtmlContent 函数 ---
+  // 检查文本是否包含 <html> 标签（无论是作为开头还是嵌入其中）
+  const isHtmlContent = (text: string) => {
+    const trimmedText = text?.trim();
+    // 只要包含 <html> 就认为是包含 HTML 内容
+    return trimmedText?.includes("<html>");
+  };
+
+  // --- 2. 提取 <body> 内容的函数 (用于纯 HTML 文档) ---
+  const extractBodyContent = (htmlString: string) => {
+    const bodyStart = htmlString.indexOf("<body");
+    const bodyEnd = htmlString.lastIndexOf("</body>");
+
+    if (bodyStart !== -1 && bodyEnd !== -1) {
+      const bodyOpenEnd = htmlString.indexOf(">", bodyStart);
+      if (bodyOpenEnd !== -1) {
+        return htmlString.substring(bodyOpenEnd + 1, bodyEnd).trim();
+      }
+    }
+    return htmlString; // Fallback
+  };
+
+  // --- 3. 提取所有 <html>...</html> 块的函数 (用于嵌入 HTML 的文本) ---
+  const extractHtmlBlocks = (text: string): string[] => {
+    const htmlBlocks: string[] = [];
+    const prefix = "<html>";
+    const suffix = "</html>";
+    let startIndex = 0;
+
+    while (startIndex < text.length) {
+      const blockStart = text.indexOf(prefix, startIndex);
+      if (blockStart === -1) break; // No more <html> found
+
+      const blockEnd = text.indexOf(suffix, blockStart);
+      if (blockEnd === -1) break; // Unmatched <html>, stop processing
+
+      // Extract the full <html>...</html> block
+      const htmlBlock = text.substring(blockStart, blockEnd + suffix.length);
+      htmlBlocks.push(htmlBlock);
+
+      // Move the search start index past the end of the current block
+      startIndex = blockEnd + suffix.length;
+    }
+
+    return htmlBlocks;
+  };
+
+  // --- 4. 定义 HTMLReactParserOptions (为表格和单元格添加样式) ---
+  const tableOptions: HTMLReactParserOptions = {
+    replace(domNode) {
+      // 处理 <table> 标签
+      if (domNode.type === "tag" && domNode.name === "table") {
+        const element = domNode as Element;
+        const existingTableClass =
+          element.attribs.className || element.attribs.class || "";
+        // 添加边框、边框合并、居中、上下边距
+        const tableBorderClasses =
+          "border border-collapse border-gray-500 mx-auto my-2";
+        const updatedTableClassName = existingTableClass
+          ? `${existingTableClass} ${tableBorderClasses}`
+          : tableBorderClasses;
+        element.attribs.className = updatedTableClassName;
+        delete element.attribs.class;
+        return undefined;
+      }
+
+      // 处理 <td> 和 <th> 标签
+      if (
+        domNode.type === "tag" &&
+        (domNode.name === "td" || domNode.name === "th")
+      ) {
+        const element = domNode as Element;
+        const existingCellClass =
+          element.attribs.className || element.attribs.class || "";
+        // 添加内边距和边框
+        const cellBorderClasses = "border border-gray-500 p-2";
+        const updatedCellClassName = existingCellClass
+          ? `${existingCellClass} ${cellBorderClasses}`
+          : cellBorderClasses;
+        element.attribs.className = updatedCellClassName;
+        delete element.attribs.class;
+        return undefined;
+      }
+
+      // 对于其他元素，使用默认行为
+      return undefined;
+    },
+  };
+
+  // --- 5. 主要的 HTML 渲染函数 ---
+  const renderHtmlContent = (text: string) => {
+    const trimmedText = text.trim();
+
+    // 情况 1: chunk.text 本身就是一个完整的 HTML 文档
+    if (trimmedText.startsWith("<html>")) {
+      try {
+        // 提取 <body> 内容并解析
+        const bodyContent = extractBodyContent(trimmedText);
+        return parse(bodyContent, tableOptions);
+      } catch (error) {
+        console.error("Error parsing standalone HTML document:", error);
+        // 如果解析失败，回退到显示原始文本
+        return <pre>{text}</pre>;
+      }
+    }
+    // 情况 2: chunk.text 是包含 HTML 块的文本
+    else if (isHtmlContent(text)) {
+      try {
+        // 提取所有 <html>...</html> 块
+        const htmlBlocks = extractHtmlBlocks(text);
+
+        if (htmlBlocks.length > 0) {
+          // 对每个 HTML 块提取 <body> 内容并解析，然后将结果组合起来
+          return (
+            <>
+              {/* 渲染 HTML 块之前的部分文本 */}
+              {text.substring(0, text.indexOf("<html>"))}
+              {/* 渲染每个解析后的 HTML 块 */}
+              {htmlBlocks.map((htmlBlock, index) => {
+                const bodyContent = extractBodyContent(htmlBlock);
+                // 使用 React Fragment 包裹，以防 parse 返回多个根元素
+                // key 用于 React 列表渲染
+                return (
+                  <React.Fragment key={index}>
+                    {parse(bodyContent, tableOptions)}
+                  </React.Fragment>
+                );
+              })}
+              {/* 渲染最后一个 HTML 块之后的部分文本 */}
+              {text.substring(text.lastIndexOf("</html>") + "</html>".length)}
+            </>
+          );
+        } else {
+          return text;
+        }
+      } catch (error) {
+        console.error("Error parsing embedded HTML blocks:", error);
+        // 如果解析嵌入的 HTML 失败，回退到显示原始文本
+        return <pre>{text}</pre>;
+      }
+    }
+    // 情况 3: 不包含 HTML，按普通文本渲染
+    else {
+      return text;
+    }
+  };
+
   const handleSaveEdit = async () => {
     if (!selectedChunk) return;
     selectedChunk.text = editText;
@@ -318,12 +465,9 @@ export default function KnowledgeBaseFileChunksPage({
             <h3 className="text-lg font-medium text-gray-700 py-6">暂无切片</h3>
           ) : (
             <div className="gap-4 p-4 w-full">
-              <div className="flex gap-4">
+              <div className="grid grid-cols-4 items-center gap-6">
                 {kbfilechunks.map((chunk) => (
-                  <Card
-                    key={chunk.id}
-                    className="flex max-h-80 w-68 py-3 gap-2"
-                  >
+                  <Card key={chunk.id} className="h-80 p-4 gap-4">
                     <CardHeader>
                       <CardTitle className="flex justify-between items-start">
                         <Badge className={activeMap[String(chunk.active)]}>
@@ -344,7 +488,7 @@ export default function KnowledgeBaseFileChunksPage({
                     </CardHeader>
                     <CardContent className="bg-gray-200/10 flex-grow overflow-y-auto overflow-x-auto pr-3 p-3 pb-2 mt-1 mb-1">
                       <div className="whitespace-pre-wrap break-words text-sm leading-relaxed whitespace-normal pr-2">
-                        {chunk.text}
+                        {renderHtmlContent(chunk.text)}
                       </div>
                     </CardContent>
                     <CardFooter className="shrink-0 gap-2">

--- a/frontend/app/knowledgebase/details/page.tsx
+++ b/frontend/app/knowledgebase/details/page.tsx
@@ -582,13 +582,13 @@ export default function KnowledgeBaseDetailPage({
     // 文件校验 (Demo功能，后续调整优化)
     const validFiles = Array.from(files).filter((file) => {
       // const isValidType = ['application/pdf', 'application/msword'].includes(file.type);
-      const isValidSize = file.size <= 10 * 1024 * 1024;
+      const isValidSize = file.size <= 100 * 1024 * 1024;
       // return isValidType && isValidSize;
       return isValidSize;
     });
 
     if (validFiles.length === 0) {
-      alert("请选择有效的文件（如 PDF 或 Word，且小于 10MB）");
+      alert("请选择有效的文件（如 PDF 或 Word，且小于 100MB）");
       setUploading(false);
       return;
     }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -24,6 +24,15 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
+      <head>
+        <title>PAI-RAG</title>
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="80x80"
+          href="https://pai-rag.oss-cn-hangzhou.aliyuncs.com/logo/pairag_logo.png"
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -45,7 +45,7 @@ export function AppSidebar({
         <div className="flex items-center space-x-2">
           <Avatar>
             <AvatarImage
-              src="https://pai-rag.oss-cn-hangzhou.aliyuncs.com/logo/pairag.png"
+              src="https://pai-rag.oss-cn-hangzhou.aliyuncs.com/logo/pairag_logo.png"
               alt="@shadcn"
             />
           </Avatar>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "framer-motion": "^12.9.2",
+        "html-react-parser": "^5.2.6",
         "jsonrepair": "^3.12.0",
         "lucide-react": "^0.503.0",
         "next": "15.3.1",
@@ -5953,6 +5954,73 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7364,6 +7432,37 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.1.tgz",
+      "integrity": "sha512-+o4Y4Z0CLuyemeccvGN4bAO20aauB2N9tFEAep5x4OW34kV4PTarBHm6RL02afYt2BMKcr0D2Agep8S3nJPIBg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "10.0.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.6.tgz",
+      "integrity": "sha512-qcpPWLaSvqXi+TndiHbCa+z8qt0tVzjMwFGFBAa41ggC+ZA5BHaMIeMJla9g3VSp4SmiZb9qyQbmbpHYpIfPOg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.1.1",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.17"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -7382,6 +7481,25 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
       }
     },
     "node_modules/ignore": {
@@ -9989,6 +10107,12 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
@@ -10967,18 +11091,18 @@
       }
     },
     "node_modules/style-to-js": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
-      "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
       "license": "MIT",
       "dependencies": {
-        "style-to-object": "1.0.8"
+        "style-to-object": "1.0.9"
       }
     },
     "node_modules/style-to-object": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
-      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "framer-motion": "^12.9.2",
+    "html-react-parser": "^5.2.6",
     "jsonrepair": "^3.12.0",
     "lucide-react": "^0.503.0",
     "next": "15.3.1",


### PR DESCRIPTION
1. 添加类型为“html-table” 和 “image-caption”的TreeNode
2. “html-table” 和 “image-caption”不进行chunk切割
3. 前端适配“html-table”，使用HTML渲染
（1）chunk.text只有html的table内容
<img width="3374" height="1400" alt="image" src="https://github.com/user-attachments/assets/ca788668-c486-4deb-bd1b-fb71bb27b0a6" />
（2）chunk.text包含了html的table和其他图片或者文本内容
<img width="804" height="576" alt="image" src="https://github.com/user-attachments/assets/3bd11765-b2d0-44ed-a8e3-f97f4a827e3e" />
<img width="848" height="622" alt="image" src="https://github.com/user-attachments/assets/f5ebf00a-a45e-4d72-97a3-1a03e2d0d801" />
