### PR TITLE
Add utc timezone info

### DIFF
--- a/backend/api/request_validate_exception.py
+++ b/backend/api/request_validate_exception.py
@@ -1,5 +1,7 @@
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
+
 from fastapi import Request
 from loguru import logger
 from fastapi import status
@@ -33,7 +35,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         content={
-            "detail": exc.errors(),
+            "detail": jsonable_encoder(exc.errors()),
             "body": body.decode() if body else None
         }
     )

--- a/backend/api/v1/config_apis/knowledgebase.py
+++ b/backend/api/v1/config_apis/knowledgebase.py
@@ -430,6 +430,7 @@ async def _batch_reprocess_files(
     for file_entity in file_entities:
         file_entity.status = FileStatus.pending
         file_entity.file_version = file_version
+        file_entity.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
         session.add(file_entity)
         reprocessed_count += 1
 

--- a/backend/db/models/chatbot.py
+++ b/backend/db/models/chatbot.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 from sqlmodel import Field, SQLModel
-from pydantic import field_validator
+from pydantic import field_validator, field_serializer
 from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, JSON, Text
 from typing import List, Optional
@@ -56,3 +56,11 @@ class ChatBotEntity(ChatBotCreate, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime),
     )
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/chatdb/chatdb.py
+++ b/backend/db/models/chatdb/chatdb.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Column, DateTime, Field, SQLModel
 from common.system_constants import DEFAULT_TENANT_ID
 from typing import Optional
@@ -33,3 +34,11 @@ class ChatDbConfigEntity(ChatDbConfig, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime),
     )
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/evaluation/dataset.py
+++ b/backend/db/models/evaluation/dataset.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, JSON, DateTime, Text
 from common.system_constants import DEFAULT_TENANT_ID
@@ -52,3 +53,11 @@ class DatasetSampleEntity(SQLModel, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime),
     )
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/evaluation/evaluator_config.py
+++ b/backend/db/models/evaluation/evaluator_config.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, DateTime
 from common.system_constants import DEFAULT_TENANT_ID
@@ -32,3 +33,11 @@ class EvaluatorConfigEntity(EvaluatorConfigCreate, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime)
     )
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/evaluation/experiment.py
+++ b/backend/db/models/evaluation/experiment.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, JSON, DateTime, Text
 from typing import Optional, List
@@ -72,6 +73,14 @@ class ExperimentEntity(SQLModel, table=True):
         sa_column=Column(DateTime)
     )
 
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()
+
 class ExperimentSampleEntity(SQLModel, table=True):
     __tablename__ = "pai_experiment_sample_entity"
 
@@ -135,3 +144,11 @@ class ExperimentSampleEntity(SQLModel, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime)
     )
+
+    @field_serializer("created_at", "updated_at", "started_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/evaluation/run_config.py
+++ b/backend/db/models/evaluation/run_config.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, JSON, DateTime
 from typing import List, Optional
@@ -44,3 +45,11 @@ class RunConfigEntity(RunConfigCreate, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime)
     )
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/guardrail.py
+++ b/backend/db/models/guardrail.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Column, DateTime, Field, SQLModel
 from common.system_constants import DEFAULT_TENANT_ID
 from typing import Optional
@@ -35,3 +36,11 @@ class GuardrailConfigEntity(GuardrailConfig, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime),
     )
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/knowledgebase/chunk.py
+++ b/backend/db/models/knowledgebase/chunk.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, JSON, DateTime, Text
 from llama_index.core.schema import TextNode
@@ -41,6 +42,13 @@ class KbChunkEntity(KbChunkModel, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None), sa_column=Column(DateTime)
     )
 
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()
 
 def create_chunk_from_text_node(kb_id: str, file_id: str, file_part: int, node: TextNode, index: int, tenant_id: str):
     return KbChunkEntity(

--- a/backend/db/models/knowledgebase/file.py
+++ b/backend/db/models/knowledgebase/file.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import List, Optional
 import uuid
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, JSON, DateTime, UniqueConstraint, Text, String
 from common.knowledgebase.types import FileStatus
@@ -49,3 +49,12 @@ class KbFileEntity(SQLModel, table=True):
     )
 
     file_metadata: dict = Field(default={}, sa_column=Column("file_metadata", JSON))
+
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/knowledgebase/file_task.py
+++ b/backend/db/models/knowledgebase/file_task.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, DateTime, UniqueConstraint, Text
 from common.knowledgebase.types import FileStatus
@@ -28,3 +29,12 @@ class KbFileTaskEntity(SQLModel, table=True):
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None), sa_column=Column(DateTime)
     )
+
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/knowledgebase/knowledgebase.py
+++ b/backend/db/models/knowledgebase/knowledgebase.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 import re
 import uuid
-from pydantic import ConfigDict, field_validator
+from pydantic import field_validator
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, JSON, DateTime, Text, UniqueConstraint
 from common.knowledgebase.constants import (
@@ -18,7 +18,7 @@ from common.knowledgebase.constants import (
 from common.knowledgebase.types import VectorIndexRetrievalType
 from typing import Optional
 from common.system_constants import DEFAULT_TENANT_ID
-
+from pydantic import field_serializer
 
 class ChunkConfig(SQLModel):
     chunk_size: int = Field(default=DEFAULT_CHUNK_SIZE)
@@ -91,7 +91,10 @@ class KbEntity(SQLModel, table=True):
             raise ValueError("知识库名称只能包含字母、数字和下划线。")
         return v
 
-    # Pydantic V2 配置
-    model_config = ConfigDict(json_encoders={
-        datetime: lambda v: v.isoformat()
-    })
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/knowledgebase/metadata.py
+++ b/backend/db/models/knowledgebase/metadata.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 import re
 import uuid
-from pydantic import field_validator
+from pydantic import field_validator, field_serializer
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, DateTime, Enum, UniqueConstraint, Text
 from common.system_constants import DEFAULT_TENANT_ID
@@ -60,9 +60,16 @@ class KbMetadataEntity(SQLModel, table=True):
     def validate_metadata_name_format(cls, v):
         # 使用正则表达式检查是否只包含字母、数字、下划线和短横线，且长度 3-50
         if not re.fullmatch(r'^[A-Za-z0-9_-]{3,50}$', v):
-            raise ValueError('Username must be 3-50 characters long and contain only letters, numbers, underscores, and hyphens.')
+            raise ValueError('Metadata name must be 3-50 characters long and contain only letters, numbers, underscores, and hyphens.')
         return v
 
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()
 
 # 记录文件-元数据映射关系
 class FileMetadataEntity(SQLModel, table=True):
@@ -83,3 +90,12 @@ class FileMetadataEntity(SQLModel, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime)
     )
+
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/knowledgebase/user_role.py
+++ b/backend/db/models/knowledgebase/user_role.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 import uuid
-from pydantic import model_validator
+from pydantic import model_validator, field_serializer
 from sqlalchemy import Column, DateTime, UniqueConstraint, Text
 from sqlmodel import Field, SQLModel
 from common.system_constants import DEFAULT_TENANT_ID
@@ -69,3 +69,11 @@ class UserRoleEntity(SQLModel, table=True):
         if not self.id:
             self.id = uuid.uuid4().hex
         return self
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/knowledgebase/vector_table_mapping.py
+++ b/backend/db/models/knowledgebase/vector_table_mapping.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 import hashlib
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Field, SQLModel
 from sqlalchemy import Column, DateTime, UniqueConstraint
 from common.system_constants import DEFAULT_TENANT_ID
@@ -36,6 +37,13 @@ class VectorTableMappingEntity(SQLModel, table=True):
         sa_column=Column(DateTime),
     )
 
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()
 
 def generate_vector_table_name(tenant_id: str, kb_id: str) -> str:
     """

--- a/backend/db/models/message.py
+++ b/backend/db/models/message.py
@@ -1,4 +1,5 @@
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Field, SQLModel
 from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, JSON
@@ -40,3 +41,11 @@ class MessageEntity(SQLModel, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime),
     )
+
+    @field_serializer("created_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()

--- a/backend/db/models/thread.py
+++ b/backend/db/models/thread.py
@@ -1,4 +1,5 @@
 import uuid
+from pydantic import field_serializer
 from sqlmodel import Field, SQLModel
 from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, Text
@@ -31,3 +32,11 @@ class ThreadEntity(SQLModel, table=True):
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         sa_column=Column(DateTime),
     )
+
+    @field_serializer("created_at", "updated_at")
+    def serialize_dt(self, dt: datetime, _info):
+        # If the datetime is naive, assume it's UTC and add 'Z'
+        if dt.tzinfo is None:
+            return f"{dt.isoformat()}Z"
+        # If it's already aware, convert to ISO format
+        return dt.isoformat()


### PR DESCRIPTION
1. 更新和创建时间加上时区信息，存储依然是utc时间，适配前端
2. 修复RequestValidation出错报Internal Server Error的问题