### PR TITLE
Extend OSS signed URL expiry from 1 hour to 72 hours

### DIFF
--- a/integrations/pairag-file/pairag/file/store/oss_store.py
+++ b/integrations/pairag-file/pairag/file/store/oss_store.py
@@ -86,7 +86,7 @@ class OssFileStore(BaseFileStore):
     async def get_url_async(self, file_path: str, tenant_id: str) -> Optional[str]:
         try:
             oss_file_key = os.path.join(self.prefix_path, file_path)
-            sign_url_task = asyncio.to_thread(self.bucket.sign_url, method="GET", key=oss_file_key, expires=3600)
+            sign_url_task = asyncio.to_thread(self.bucket.sign_url, method="GET", key=oss_file_key, expires=72 * 3600)
             oss_url = await sign_url_task
             # 如果是内网地址，替换为公网地址以便外部访问
             if self.is_internal:

--- a/integrations/pairag-file/pyproject.toml
+++ b/integrations/pairag-file/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pairag-file"
-version = "2.1.37"
+version = "2.1.38"
 description = "PAI-RAG file processing library."
 authors = []
 readme = "README.md"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5569,13 +5569,13 @@ files = [
 
 [[package]]
 name = "pairag-file"
-version = "2.1.37"
+version = "2.1.38"
 description = "PAI-RAG file processing library."
 optional = false
 python-versions = ">=3.11,<3.13"
 groups = ["main"]
 files = [
-    {file = "pairag_file-2.1.37-py3-none-any.whl", hash = "sha256:93c9bcbed6e5d8177172b4757afcd354d5b2ae46e3b310b8b0684251c242c1ab"},
+    {file = "pairag_file-2.1.38-py3-none-any.whl", hash = "sha256:b9f524c0b21011ac057f4071d1ecdf1b00ed38bfddfeeaf1a664ead0f0b2e8d4"},
 ]
 
 [package.dependencies]
@@ -5610,7 +5610,7 @@ xlrd = ">=2.0.2,<3.0.0"
 
 [package.source]
 type = "url"
-url = "https://pai-rag.oss-cn-hangzhou.aliyuncs.com/packages/python_wheels/pairag_file-2.1.37-py3-none-any.whl"
+url = "https://pai-rag.oss-cn-hangzhou.aliyuncs.com/packages/python_wheels/pairag_file-2.1.38-py3-none-any.whl"
 
 [[package]]
 name = "pandas"
@@ -9754,4 +9754,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.0,<3.13"
-content-hash = "6791fafe8c5c185dd0657af7417e5a97be137af71b5091543bca732c1b11798f"
+content-hash = "2fb2d539143bcb90627809c47af2ab8f6615a5761f09cb75a5b2891d63fb188b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ json5 = "^0.12.1"
 aiomysql = "^0.3.2"
 aiofiles = "24.1.0"
 alibabacloud-credentials = "1.0.1"
-pairag-file = {url = "https://pai-rag.oss-cn-hangzhou.aliyuncs.com/packages/python_wheels/pairag_file-2.1.37-py3-none-any.whl"}
+pairag-file = {url = "https://pai-rag.oss-cn-hangzhou.aliyuncs.com/packages/python_wheels/pairag_file-2.1.38-py3-none-any.whl"}
 aiocache = "^0.12.3"
 opentelemetry-instrumentation-fastapi = "^0.60b1"
 opentelemetry-exporter-otlp-proto-http = "^1.39.1"


### PR DESCRIPTION
## Summary
- OSS signed URL 的过期时间从 1 小时（3600秒）延长至 72 小时（72 * 3600秒），避免签名链接过快失效

## Test plan
- [ ] 验证 get_url_async 返回的签名 URL 过期时间为 72 小时

🤖 Generated with [Claude Code](https://claude.com/claude-code)