### PR TITLE
Redesign frontend with modern indigo tech theme

### DIFF
--- a/frontend/app/apps/page.tsx
+++ b/frontend/app/apps/page.tsx
@@ -86,7 +86,7 @@ const ChatbotPage = () => {
   return (
     <div className="flex flex-col h-screen px-6 space-y-2">
       <div className="flex justify-between items-center h-1/10">
-        <h1 className="text-xl font-medium">{t('apps.title')}</h1>
+        <h1 className="page-title">{t('apps.title')}</h1>
         <Button
           className="px-4 py-2 bg-primary rounded-md text-sm font-medium hover:bg-primary/90 w-40"
           onClick={()=>{router.push('/apps/create')}}
@@ -115,7 +115,7 @@ const ChatbotPage = () => {
                 router.push(`/apps/${bot.app_id}`);
               }}
               key={bot.id}
-              className="flex flex-col border rounded-lg shadow-sm h-full gap-0 py-0 transition-shadow hover:shadow-md hover:bg-muted/50 duration-300"
+              className="flex flex-col border rounded-lg shadow-sm h-full gap-0 py-0 card-hover-glow duration-300"
             >
               <CardHeader>
                 <CardTitle className="text-md flex pt-4 pb-1">

--- a/frontend/app/assistant.tsx
+++ b/frontend/app/assistant.tsx
@@ -45,7 +45,7 @@ export const Assistant = () => {
 
   return (
     <div className="flex flex-col h-screen">
-      <header className="flex p-1 border-b">
+      <header className="flex p-1 border-b border-border/50">
         <ModelSelector
           selectedModel={{
             model_id: model || undefined,

--- a/frontend/app/config/cache/page.tsx
+++ b/frontend/app/config/cache/page.tsx
@@ -18,9 +18,7 @@ export default function CacheConfig() {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
       });
-
       if (!res.ok) throw new Error(t('config.cache.clearFailed'));
-
       const data = await res.json();
       const cleared = data?.data?.cleared ?? 0;
       toast.success(`${t('config.cache.clearSuccess')} (${cleared})`);
@@ -32,22 +30,28 @@ export default function CacheConfig() {
   };
 
   return (
-    <div id="cache">
-      <div className="transition-colors rounded-lg p-4 overflow-hidden duration-200">
-        <div className="flex flex-col items-center justify-center py-12 border-2 border-dashed border-gray-200 rounded-xl bg-gray-50">
-          <h2 className="text-xl font-medium text-gray-800" suppressHydrationWarning>
-            {t('config.cache.title')}
-          </h2>
+    <div id="cache" className="settings-page">
+      <div className="settings-page-header">
+        <h1 className="page-title" suppressHydrationWarning>
+          {t('config.cache.title')}
+        </h1>
+      </div>
 
-          <div className="max-w-xl w-full mx-auto mt-8 space-y-6">
-            <div className="border rounded-lg p-6 bg-white">
-              <h3 className="text-base font-medium text-gray-700 mb-2" suppressHydrationWarning>
-                {t('config.cache.metadataSchemaTitle')}
-              </h3>
-              <p className="text-sm text-gray-500 mb-4" suppressHydrationWarning>
-                {t('config.cache.metadataSchemaDescription')}
-              </p>
+      <div className="settings-page-content">
+        <div className="space-y-6">
+          <div>
+            <div className="dialog-section-title mb-2">缓存项</div>
+            <div className="form-row-inline">
+              <div className="form-row-inline-label">
+                <span className="title" suppressHydrationWarning>
+                  {t('config.cache.metadataSchemaTitle')}
+                </span>
+                <span className="hint" suppressHydrationWarning>
+                  {t('config.cache.metadataSchemaDescription')}
+                </span>
+              </div>
               <Button
+                size="sm"
                 variant="destructive"
                 onClick={handleClearMetadataSchemaCache}
                 disabled={isClearing}

--- a/frontend/app/config/chatdb/page.tsx
+++ b/frontend/app/config/chatdb/page.tsx
@@ -3,14 +3,18 @@
 import { Button } from '@/components/ui/button';
 import React, { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { toast } from 'sonner';
 import { LlmConfig } from '@/app/config/model/llm/page';
 import { useRouter } from 'next/navigation';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
-
 
 interface ChatDbConfig {
   dialect: string;
@@ -25,119 +29,97 @@ interface ChatDbConfig {
 export default function ChatdbConfig() {
   const { t } = useI18n();
   const [dbConfig, setDbConfig] = useState<ChatDbConfig>({
-    dialect: "mysql",
-    host: "",
+    dialect: 'mysql',
+    host: '',
     port: 3306,
-    username: "",
-    password: "",
-    db_name: "",
-    model_id: "",
+    username: '',
+    password: '',
+    db_name: '',
+    model_id: '',
   });
 
   const [llms, setLlms] = useState<LlmConfig[]>([]);
-
-  const [isConnecting, setIsConnecting] = useState(false); // 连接测试中
-  const [isLoading, setIsLoading] = useState(false); // 加载状态
-  const [isSaving, setIsSaving] = useState(false); // 加载状态
-  const [error, setError] = useState(''); // 错误提示
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const { tenantFetch } = useTenantFetch();
-
   const router = useRouter();
-  // 初始化加载配置
+
   useEffect(() => {
     const fetchConfig = async () => {
       try {
-        setIsLoading(true);
-        setError('');
-
         const [llmRes, dbRes] = await Promise.all([
           tenantFetch(`/api/config/llms`),
-          tenantFetch(`/api/config/chatdb`)]);
-
+          tenantFetch(`/api/config/chatdb`),
+        ]);
 
         const llmResponse = await llmRes.json();
         if (llmResponse.code === 200) {
           setLlms(llmResponse.data.items);
-        }
-        else {
+        } else {
           toast.error(t('config.chatdb.loadLlmFailed') + ': ' + llmResponse.message);
         }
 
-        const dbResponse = await dbRes.json()
-        if (dbResponse.code === 200) {
-          if (dbResponse.data.length > 0) {
-            if (dbResponse.data[0].encrypted_password !== "" && dbResponse.data[0].encrypted_password !== undefined) {
-              setDbConfig({...dbResponse.data[0], password: "******"})
-            }
-            else {
-              setDbConfig(dbResponse.data[0]);
-            }
+        const dbResponse = await dbRes.json();
+        if (dbResponse.code === 200 && dbResponse.data.length > 0) {
+          if (
+            dbResponse.data[0].encrypted_password !== '' &&
+            dbResponse.data[0].encrypted_password !== undefined
+          ) {
+            setDbConfig({ ...dbResponse.data[0], password: '******' });
+          } else {
+            setDbConfig(dbResponse.data[0]);
           }
-        }
-        else {
+        } else if (dbResponse.code !== 200) {
           toast.error(t('config.chatdb.fetchChatdbFailed') + ': ' + dbResponse.message);
         }
-
       } catch (err: any) {
-        toast.error(t('config.chatdb.configLoadFailed'))
-      } finally {
-        setIsLoading(false);
+        toast.error(t('config.chatdb.configLoadFailed'));
       }
     };
-
     fetchConfig();
   }, []);
 
   const checkConfig = () => {
     if (!dbConfig.host) {
-      toast.warning(t('config.chatdb.hostRequired'))
-      return;
+      toast.warning(t('config.chatdb.hostRequired'));
+      return false;
     }
-      if (!dbConfig.port) {
-      toast.warning(t('config.chatdb.portRequired'))
-      return;
+    if (!dbConfig.port) {
+      toast.warning(t('config.chatdb.portRequired'));
+      return false;
     }
     if (!dbConfig.username) {
-      toast.warning(t('config.chatdb.usernameRequired'))
-      return;
+      toast.warning(t('config.chatdb.usernameRequired'));
+      return false;
     }
     if (!dbConfig.password) {
-      toast.warning(t('config.chatdb.passwordRequired'))
-      return;
+      toast.warning(t('config.chatdb.passwordRequired'));
+      return false;
     }
     if (!dbConfig.db_name) {
       toast.warning(t('config.chatdb.dbNameRequired'));
-      return;
+      return false;
     }
-    if (dbConfig.dialect !== 'mysql' && dbConfig.dialect != "postgresql") {
+    if (dbConfig.dialect !== 'mysql' && dbConfig.dialect !== 'postgresql') {
       toast.warning(t('config.chatdb.dialectSupported'));
-      return;
+      return false;
     }
-  }
-  const handleConnect = async() => {
-    checkConfig();
+    return true;
+  };
 
+  const handleConnect = async () => {
+    if (!checkConfig()) return;
     try {
       setIsConnecting(true);
-
       const password = dbConfig.password === '******' ? '' : dbConfig.password;
       const res = await tenantFetch(`/api/config/chatdb/connectiontest`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-
-              body: JSON.stringify({
-                ...dbConfig,
-                password: password,
-              }),
-            });
-
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...dbConfig, password }),
+      });
       const response = await res.json();
-      if (response.code !== 200) {
-        toast.error(response.message);
-      }
-      else {
-        toast.success(t('config.chatdb.connectSuccess'))
-      }
+      if (response.code !== 200) toast.error(response.message);
+      else toast.success(t('config.chatdb.connectSuccess'));
     } catch (err: any) {
       toast.error(`${t('config.chatdb.connectFailed')}: ${err.message}`);
     } finally {
@@ -145,32 +127,19 @@ export default function ChatdbConfig() {
     }
   };
 
-  // 保存配置
   const handleSave = async () => {
-    checkConfig();
-
+    if (!checkConfig()) return;
     try {
       setIsSaving(true);
-
       const password = dbConfig.password === '******' ? '' : dbConfig.password;
-
       const res = await tenantFetch(`/api/config/chatdb`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-
-        body: JSON.stringify({
-          ...dbConfig,
-          password: password,
-        }),
+        body: JSON.stringify({ ...dbConfig, password }),
       });
-
       const response = await res.json();
-      if (response.code !== 200) {
-        toast.error(response.message);
-      }
-      else {
-        toast.success(t('config.chatdb.saveSuccess'))
-      }
+      if (response.code !== 200) toast.error(response.message);
+      else toast.success(t('config.chatdb.saveSuccess'));
     } catch (err: any) {
       toast.error(`${t('config.chatdb.saveFailed')}: ${err.message}`);
     } finally {
@@ -179,130 +148,156 @@ export default function ChatdbConfig() {
   };
 
   return (
-    <div id="chatdb">
-        <div className="py-6 px-6">
-          <h2 className="text-xl font-medium text-gray-800">{t('config.chatdb.title')}</h2>
-            <div className="flex py-6 px-4">
-              <Label htmlFor="basemodel" className="w-[90px]">
-                {t('config.chatdb.baseModel')} <span className="text-destructive">*</span>{' '}
-              </Label>
-              <div className="px-6">
-                {llms.length > 0 ? (
-                  <Select
-                    value={dbConfig.model_id}
-                    onValueChange={(value) =>
-                      setDbConfig((prev) => ({
-                        ...prev,
-                        model_id: value,
-                      }))
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder={t('config.chatdb.selectBaseModel')} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {llms.map((llm) => (
-                        <SelectItem key={llm.id} value={llm.model_id}>
-                          {llm.model_id}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                ) : (
-                  <div>
-                    <p className="text-sm text-muted-foreground">{t('config.chatdb.noModelConfigured')}</p>
-                    <Button
-                      variant="outline"
-                      onClick={() => {
-                        router.push('/config/model/llm');
-                      }}
-                    >
-                      {t('config.chatdb.goToAdd')}
-                    </Button>
-                  </div>
-                )}
-              </div>
-            </div>
-            <div className="flex py-3 px-4">
-              <Label htmlFor="basemodel" className="w-[90px]">
-                {t('config.chatdb.dbType')} <span className="text-destructive">*</span>{' '}
-              </Label>
-              <div className="px-6">
-                  <Select
-                    value={dbConfig.dialect}
-                    onValueChange={(value) =>
-                      setDbConfig((prev) => ({
-                        ...prev,
-                        dialect: value,
-                      }))
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder={t('config.chatdb.selectDbType')} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem key="mysql" value="mysql">
-                        mysql
+    <div id="chatdb" className="settings-page">
+      <div className="settings-page-header">
+        <h1 className="page-title">{t('config.chatdb.title')}</h1>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleConnect}
+            disabled={isConnecting}
+          >
+            {isConnecting
+              ? t('config.chatdb.connecting')
+              : t('config.chatdb.testConnection')}
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={isSaving}>
+            {isSaving
+              ? t('config.chatdb.saving')
+              : t('config.chatdb.saveChatdbConfig')}
+          </Button>
+        </div>
+      </div>
+
+      <div className="settings-page-content">
+        <div className="space-y-6">
+          <div>
+            <div className="dialog-section-title mb-2">问答模型</div>
+            <div>
+              <label className="form-label">
+                {t('config.chatdb.baseModel')}
+                <span className="required">*</span>
+              </label>
+              {llms.length > 0 ? (
+                <Select
+                  value={dbConfig.model_id}
+                  onValueChange={(v) =>
+                    setDbConfig((prev) => ({ ...prev, model_id: v }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder={t('config.chatdb.selectBaseModel')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {llms.map((llm) => (
+                      <SelectItem key={llm.id} value={llm.model_id}>
+                        {llm.model_id}
                       </SelectItem>
-                      <SelectItem key="postgresql" value="postgresql">
-                        postgresql
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-              </div>
-            </div>
-            <div className="flex px-4 py-3 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="host">{t('config.chatdb.host')}</Label>
-                <Input id="host" value={dbConfig.host || ''} onChange={(e) => {
-                  setDbConfig({...dbConfig, host: e.target.value});
-                }} />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="port">{t('config.chatdb.port')}</Label>
-                <Input id="port" type="number" value={dbConfig.port} onChange={(e) => {
-                  setDbConfig({...dbConfig, port: parseInt(e.target.value)});
-                }} />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="database">{t('config.chatdb.database')}</Label>
-                <Input id="database"  value={dbConfig.db_name} onChange={(e) => {
-                  setDbConfig({...dbConfig, db_name: e.target.value});
-                }} />
-              </div>
-            </div>
-            <div className="flex px-4 py-6 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="user">{t('config.chatdb.username')}</Label>
-                <Input id="user" type="string" value={dbConfig.username || ''} onChange={(e) => {
-                  setDbConfig({...dbConfig, username: e.target.value});
-                  }} />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="password">{t('config.chatdb.password')}</Label>
-                <Input id="password" type="password" value={dbConfig.password  || ''} onChange={(e) => {
-                  setDbConfig({...dbConfig, password: e.target.value});
-                  }} />
-              </div>
-            </div>
-            <div className="flex gap-12 px-4">
-              <Button
-                onClick={handleSave}
-                disabled={isSaving}
-                className="mt-4 text-white rounded-lg transition-colors"
-              >
-                {isSaving ? t('config.chatdb.saving') : t('config.chatdb.saveChatdbConfig')}
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={handleConnect}
-                disabled={isConnecting}
-                className="mt-4 rounded-lg transition-colors"
-              >
-                {isConnecting ? t('config.chatdb.connecting') : t('config.chatdb.testConnection')}
-              </Button>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <div className="flex items-center justify-between rounded-md border border-dashed p-3">
+                  <p className="text-sm text-muted-foreground">
+                    {t('config.chatdb.noModelConfigured')}
+                  </p>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => router.push('/config/model')}
+                  >
+                    {t('config.chatdb.goToAdd')}
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
+
+          <div>
+            <div className="dialog-section-title mb-2">数据库连接</div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="dialect" className="form-label">
+                  {t('config.chatdb.dbType')}
+                  <span className="required">*</span>
+                </label>
+                <Select
+                  value={dbConfig.dialect}
+                  onValueChange={(v) => setDbConfig((prev) => ({ ...prev, dialect: v }))}
+                >
+                  <SelectTrigger id="dialect">
+                    <SelectValue placeholder={t('config.chatdb.selectDbType')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="mysql">MySQL</SelectItem>
+                    <SelectItem value="postgresql">PostgreSQL</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <label htmlFor="database" className="form-label">
+                  {t('config.chatdb.database')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="database"
+                  value={dbConfig.db_name}
+                  onChange={(e) => setDbConfig({ ...dbConfig, db_name: e.target.value })}
+                />
+              </div>
+              <div>
+                <label htmlFor="host" className="form-label">
+                  {t('config.chatdb.host')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="host"
+                  value={dbConfig.host || ''}
+                  onChange={(e) => setDbConfig({ ...dbConfig, host: e.target.value })}
+                />
+              </div>
+              <div>
+                <label htmlFor="port" className="form-label">
+                  {t('config.chatdb.port')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="port"
+                  type="number"
+                  value={dbConfig.port}
+                  onChange={(e) =>
+                    setDbConfig({ ...dbConfig, port: parseInt(e.target.value) || 0 })
+                  }
+                />
+              </div>
+              <div>
+                <label htmlFor="user" className="form-label">
+                  {t('config.chatdb.username')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="user"
+                  value={dbConfig.username || ''}
+                  onChange={(e) => setDbConfig({ ...dbConfig, username: e.target.value })}
+                />
+              </div>
+              <div>
+                <label htmlFor="password" className="form-label">
+                  {t('config.chatdb.password')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="password"
+                  type="password"
+                  value={dbConfig.password || ''}
+                  onChange={(e) => setDbConfig({ ...dbConfig, password: e.target.value })}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/app/config/code_sandbox/page.tsx
+++ b/frontend/app/config/code_sandbox/page.tsx
@@ -3,29 +3,34 @@
 import { Button } from '@/components/ui/button';
 import React, { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { toast } from 'sonner';
 import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
-const MASK_API_KEY = '******'
+const MASK_API_KEY = '******';
 
 export default function CodeSandboxConfig() {
   const { t } = useI18n();
   const [isEnabled, setIsEnabled] = useState(false);
-  const [configType, setConfigType] = useState('aliyun-fc'); // 目前仅支持 aliyun-fc
+  const [configType, setConfigType] = useState('aliyun-fc');
   const [aliyunId, setAliyunId] = useState('');
   const [interpreterId, setInterpreterId] = useState('');
   const [interpreterName, setInterpreterName] = useState('');
   const [apiKey, setApiKey] = useState('');
-  const [hasApiKey, setHasApiKey] = useState(false); // 标记是否存在 API key
+  const [hasApiKey, setHasApiKey] = useState(false);
   const [timeoutDefault, setTimeoutDefault] = useState(50);
   const [isSaving, setIsSaving] = useState(false);
   const { tenantFetch } = useTenantFetch();
-  // 初始化加载配置
+
   useEffect(() => {
     const fetchConfig = async () => {
       try {
@@ -33,12 +38,9 @@ export default function CodeSandboxConfig() {
           method: 'GET',
           headers: { 'Content-Type': 'application/json' },
         });
-
         if (!res.ok) throw new Error(t('config.codeSandbox.loadError'));
-
         const response = await res.json();
         const config = response?.data;
-
         if (config) {
           setIsEnabled(config.enabled || false);
           setConfigType(config.type || 'aliyun-fc');
@@ -54,31 +56,23 @@ export default function CodeSandboxConfig() {
         toast.error(err.message);
       }
     };
-
     fetchConfig();
   }, []);
 
   const handleSave = async () => {
     try {
       setIsSaving(true);
-
       const payload: Record<string, any> = {
         enabled: isEnabled,
         type: configType,
         timeout_default: timeoutDefault,
       };
-
-      // 仅当用户输入了值才提交（避免覆盖已有值为空）
       if (aliyunId) payload.aliyun_id = aliyunId;
       if (interpreterId) payload.interpreter_id = interpreterId;
       if (interpreterName) payload.interpreter_name = interpreterName;
-      // 如果用户输入的是占位符，则不更新 API key（保持原值）；否则更新
       if (apiKey !== MASK_API_KEY) {
         payload.api_key = apiKey || null;
       }
-      if (isEnabled) payload.enabled = isEnabled;
-      if (timeoutDefault) payload.timeout_default = timeoutDefault;
-
 
       const res = await tenantFetch(`/api/config/code_sandbox`, {
         method: 'POST',
@@ -87,10 +81,8 @@ export default function CodeSandboxConfig() {
       });
 
       if (!res.ok) throw new Error(t('config.codeSandbox.saveFailed'));
-
       toast.success(t('config.codeSandbox.saveSuccess'));
-      
-      // 重新加载配置以更新状态
+
       const refreshRes = await tenantFetch(`/api/config/code_sandbox`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
@@ -112,46 +104,55 @@ export default function CodeSandboxConfig() {
   };
 
   return (
-    <div id="codesandbox">
-      <div className="transition-colors rounded-lg p-4 overflow-hidden duration-200">
-        <div className="flex flex-col items-center justify-center py-12 border-2 border-dashed border-gray-200 rounded-xl bg-gray-50">
-          <h2 className="text-xl font-medium text-gray-800">{t('config.codeSandbox.title')}</h2>
+    <div id="codesandbox" className="settings-page">
+      <div className="settings-page-header">
+        <h1 className="page-title">{t('config.codeSandbox.title')}</h1>
+        <Button size="sm" onClick={handleSave} disabled={isSaving}>
+          {isSaving ? t('common.saving') : t('config.codeSandbox.saveConfig')}
+        </Button>
+      </div>
 
-          <div className="grid gap-4 py-4 w-full max-w-2xl">
-            {/* 启用开关 */}
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label className="text-right">{t('config.codeSandbox.enableSandbox')}</Label>
-              <div className="col-span-3 flex items-center space-x-2">
-                <Switch
-                  checked={isEnabled}
-                  onCheckedChange={setIsEnabled}
-                />
-                <span className="text-sm text-gray-600">
-                  {isEnabled ? t('config.codeSandbox.enabled') : t('config.codeSandbox.disabled')}
+      <div className="settings-page-content">
+        <div className="space-y-6">
+          <div>
+            <div className="dialog-section-title mb-2">沙箱状态</div>
+            <div className="form-row-inline">
+              <div className="form-row-inline-label">
+                <span className="title">{t('config.codeSandbox.enableSandbox')}</span>
+                <span className="hint">
+                  {isEnabled
+                    ? t('config.codeSandbox.enabled')
+                    : t('config.codeSandbox.disabled')}
                 </span>
               </div>
+              <Switch checked={isEnabled} onCheckedChange={setIsEnabled} />
             </div>
+          </div>
 
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label className="text-right">{t('config.codeSandbox.sandboxType')}</Label>
-              <div className="col-span-3">
-                <Select value={configType} onValueChange={setConfigType} disabled>
-                  <SelectTrigger>
-                    <SelectValue placeholder={t('config.codeSandbox.selectSandboxType')} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="aliyun-fc">{t('config.codeSandbox.aliyunFcSandbox')}</SelectItem>
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-gray-500 mt-1">{t('config.codeSandbox.currentlyOnlySupported')}</p>
-              </div>
-            </div>
+          <div>
+            <div className="dialog-section-title mb-2">沙箱类型</div>
+            <Select value={configType} onValueChange={setConfigType} disabled>
+              <SelectTrigger>
+                <SelectValue placeholder={t('config.codeSandbox.selectSandboxType')} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="aliyun-fc">
+                  {t('config.codeSandbox.aliyunFcSandbox')}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('config.codeSandbox.currentlyOnlySupported')}
+            </p>
+          </div>
 
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="aliyun_id" className="text-right">
-                {t('config.codeSandbox.aliyunId')}
-              </Label>
-              <div className="col-span-3">
+          <div>
+            <div className="dialog-section-title mb-2">Aliyun FC 凭证</div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="aliyun_id" className="form-label">
+                  {t('config.codeSandbox.aliyunId')}
+                </label>
                 <Input
                   id="aliyun_id"
                   value={aliyunId}
@@ -159,41 +160,10 @@ export default function CodeSandboxConfig() {
                   placeholder={t('config.codeSandbox.aliyunIdPlaceholder')}
                 />
               </div>
-            </div>
-
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="interpreter_id" className="text-right">
-                {t('config.codeSandbox.interpreterId')}
-              </Label>
-              <div className="col-span-3">
-                <Input
-                  id="interpreter_id"
-                  value={interpreterId}
-                  onChange={(e) => setInterpreterId(e.target.value)}
-                  placeholder={t('config.codeSandbox.interpreterIdPlaceholder')}
-                />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="interpreter_name" className="text-right">
-                {t('config.codeSandbox.interpreterName')}
-              </Label>
-              <div className="col-span-3">
-                <Input
-                  id="interpreter_name"
-                  value={interpreterName}
-                  onChange={(e) => setInterpreterName(e.target.value)}
-                  placeholder={t('config.codeSandbox.interpreterNamePlaceholder')}
-                />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="api_key" className="text-right">
-                {t('config.codeSandbox.apiKey')}
-              </Label>
-              <div className="col-span-3">
+              <div>
+                <label htmlFor="api_key" className="form-label">
+                  {t('config.codeSandbox.apiKey')}
+                </label>
                 <Input
                   id="api_key"
                   type="password"
@@ -202,31 +172,51 @@ export default function CodeSandboxConfig() {
                   placeholder={t('config.codeSandbox.apiKeyPlaceholder')}
                 />
               </div>
-            </div>
-
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="timeout_default" className="text-right">
-                {t('config.codeSandbox.defaultTimeout')}({timeoutDefault})
-              </Label>
-              <div className="col-span-3">
-                <Slider
-                  value={[timeoutDefault]}
-                  max={300}
-                  min={10}
-                  step={5}
-                  onValueChange={(value) => setTimeoutDefault(value[0])}
+              <div>
+                <label htmlFor="interpreter_id" className="form-label">
+                  {t('config.codeSandbox.interpreterId')}
+                </label>
+                <Input
+                  id="interpreter_id"
+                  value={interpreterId}
+                  onChange={(e) => setInterpreterId(e.target.value)}
+                  placeholder={t('config.codeSandbox.interpreterIdPlaceholder')}
+                />
+              </div>
+              <div>
+                <label htmlFor="interpreter_name" className="form-label">
+                  {t('config.codeSandbox.interpreterName')}
+                </label>
+                <Input
+                  id="interpreter_name"
+                  value={interpreterName}
+                  onChange={(e) => setInterpreterName(e.target.value)}
+                  placeholder={t('config.codeSandbox.interpreterNamePlaceholder')}
                 />
               </div>
             </div>
           </div>
 
-          <Button
-            onClick={handleSave}
-            disabled={isSaving}
-            className="mt-4 px-4 py-2 text-white rounded-lg transition-colors"
-          >
-            {isSaving ? t('common.saving') : t('config.codeSandbox.saveConfig')}
-          </Button>
+          <div>
+            <div className="dialog-section-title mb-2">执行参数</div>
+            <div className="form-row-inline">
+              <div className="form-row-inline-label">
+                <span className="title">
+                  {t('config.codeSandbox.defaultTimeout')}({timeoutDefault}s)
+                </span>
+                <span className="hint">单次代码执行超时时间 (10–300 秒)</span>
+              </div>
+              <div className="w-48">
+                <Slider
+                  value={[timeoutDefault]}
+                  max={300}
+                  min={10}
+                  step={5}
+                  onValueChange={(v) => setTimeoutDefault(v[0])}
+                />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/app/config/guardrail/page.tsx
+++ b/frontend/app/config/guardrail/page.tsx
@@ -3,27 +3,41 @@
 import { Button } from '@/components/ui/button';
 import React, { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { toast } from 'sonner';
+import { ExternalLink } from 'lucide-react';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
 export default function GuardrailConfig() {
   const { t, language } = useI18n();
 
-  // Dynamic region names based on language
   const getRegionName = (region: string, network: string) => {
-    const regionKey = region.toLowerCase().replace('-', '') as 'shanghai' | 'beijing' | 'hangzhou' | 'shenzhen' | 'chengdu' | 'singapore';
+    const regionKey = region.toLowerCase().replace('-', '') as
+      | 'shanghai'
+      | 'beijing'
+      | 'hangzhou'
+      | 'shenzhen'
+      | 'chengdu'
+      | 'singapore';
     const regionMap: Record<string, string> = {
-      'shanghai': t('config.guardrail.regionShanghai'),
-      'beijing': t('config.guardrail.regionBeijing'),
-      'hangzhou': t('config.guardrail.regionHangzhou'),
-      'shenzhen': t('config.guardrail.regionShenzhen'),
-      'chengdu': t('config.guardrail.regionChengdu'),
-      'singapore': t('config.guardrail.regionSingapore'),
+      shanghai: t('config.guardrail.regionShanghai'),
+      beijing: t('config.guardrail.regionBeijing'),
+      hangzhou: t('config.guardrail.regionHangzhou'),
+      shenzhen: t('config.guardrail.regionShenzhen'),
+      chengdu: t('config.guardrail.regionChengdu'),
+      singapore: t('config.guardrail.regionSingapore'),
     };
-    const networkText = network === 'public' ? t('config.guardrail.publicNetwork') : t('config.guardrail.privateNetwork');
+    const networkText =
+      network === 'public'
+        ? t('config.guardrail.publicNetwork')
+        : t('config.guardrail.privateNetwork');
     return `${regionMap[regionKey]}（${networkText}）`;
   };
 
@@ -41,83 +55,63 @@ export default function GuardrailConfig() {
     getRegionName('singapore', 'private'),
   ];
 
-  const REGION_ID_MAP = new Map(
-    [
-      [getRegionName('shanghai', 'public'), "cn-shanghai"],
-      [getRegionName('shanghai', 'private'), "cn-shanghai"],
-      [getRegionName('beijing', 'public'), "cn-beijing"],
-      [getRegionName('beijing', 'private'), "cn-beijing"],
-      [getRegionName('hangzhou', 'public'), "cn-hangzhou"],
-      [getRegionName('hangzhou', 'private'), "cn-hangzhou"],
-      [getRegionName('shenzhen', 'public'), "cn-shenzhen"],
-      [getRegionName('shenzhen', 'private'), "cn-shenzhen"],
-      [getRegionName('chengdu', 'public'), "cn-chengdu"],
-      [getRegionName('singapore', 'public'), "ap-southeast-1"],
-      [getRegionName('singapore', 'private'), "ap-southeast-1"],
-    ]
-  );
+  const REGION_ID_MAP = new Map([
+    [getRegionName('shanghai', 'public'), 'cn-shanghai'],
+    [getRegionName('shanghai', 'private'), 'cn-shanghai'],
+    [getRegionName('beijing', 'public'), 'cn-beijing'],
+    [getRegionName('beijing', 'private'), 'cn-beijing'],
+    [getRegionName('hangzhou', 'public'), 'cn-hangzhou'],
+    [getRegionName('hangzhou', 'private'), 'cn-hangzhou'],
+    [getRegionName('shenzhen', 'public'), 'cn-shenzhen'],
+    [getRegionName('shenzhen', 'private'), 'cn-shenzhen'],
+    [getRegionName('chengdu', 'public'), 'cn-chengdu'],
+    [getRegionName('singapore', 'public'), 'ap-southeast-1'],
+    [getRegionName('singapore', 'private'), 'ap-southeast-1'],
+  ]);
 
-  const REGION_ENDPOINT_MAP = new Map(
-    [
-      [getRegionName('shanghai', 'public'), "green-cip.cn-shanghai.aliyuncs.com"],
-      [getRegionName('shanghai', 'private'), "green-cip-vpc.cn-shanghai.aliyuncs.com"],
-      [getRegionName('beijing', 'public'), "green-cip.cn-beijing.aliyuncs.com"],
-      [getRegionName('beijing', 'private'), "green-cip-vpc.cn-beijing.aliyuncs.com"],
-      [getRegionName('hangzhou', 'public'), "green-cip.cn-hangzhou.aliyuncs.com"],
-      [getRegionName('hangzhou', 'private'), "green-cip-vpc.cn-hangzhou.aliyuncs.com"],
-      [getRegionName('shenzhen', 'public'), "green-cip.cn-shenzhen.aliyuncs.com"],
-      [getRegionName('shenzhen', 'private'), "green-cip-vpc.cn-shenzhen.aliyuncs.com"],
-      [getRegionName('chengdu', 'public'), "green-cip.cn-chengdu.aliyuncs.com"],
-      [getRegionName('singapore', 'public'), "green-cip.ap-southeast-1.aliyuncs.com"],
-      [getRegionName('singapore', 'private'), "green-cip-vpc.ap-southeast-1.aliyuncs.com"],
-    ]
-  );
+  const REGION_ENDPOINT_MAP = new Map([
+    [getRegionName('shanghai', 'public'), 'green-cip.cn-shanghai.aliyuncs.com'],
+    [getRegionName('shanghai', 'private'), 'green-cip-vpc.cn-shanghai.aliyuncs.com'],
+    [getRegionName('beijing', 'public'), 'green-cip.cn-beijing.aliyuncs.com'],
+    [getRegionName('beijing', 'private'), 'green-cip-vpc.cn-beijing.aliyuncs.com'],
+    [getRegionName('hangzhou', 'public'), 'green-cip.cn-hangzhou.aliyuncs.com'],
+    [getRegionName('hangzhou', 'private'), 'green-cip-vpc.cn-hangzhou.aliyuncs.com'],
+    [getRegionName('shenzhen', 'public'), 'green-cip.cn-shenzhen.aliyuncs.com'],
+    [getRegionName('shenzhen', 'private'), 'green-cip-vpc.cn-shenzhen.aliyuncs.com'],
+    [getRegionName('chengdu', 'public'), 'green-cip.cn-chengdu.aliyuncs.com'],
+    [getRegionName('singapore', 'public'), 'green-cip.ap-southeast-1.aliyuncs.com'],
+    [getRegionName('singapore', 'private'), 'green-cip-vpc.ap-southeast-1.aliyuncs.com'],
+  ]);
+
   const [aliyunHasKey, setAliyunHasKey] = useState(false);
-  const [aliyunAK, setAliyunAK] = useState(''); // AccessKey ID
-  const [aliyunSK, setAliyunSK] = useState(''); // AccessKey Secret
+  const [aliyunAK, setAliyunAK] = useState('');
+  const [aliyunSK, setAliyunSK] = useState('');
   const [regionName, setRegionName] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [error, setError] = useState('');
-
   const { tenantFetch } = useTenantFetch();
-  
-  // Initialize and load configuration
+
   useEffect(() => {
     const fetchConfig = async () => {
       try {
-        setIsLoading(true);
-        setError('');
-
         const res = await tenantFetch(`/api/config/guardrail`, {
           method: 'GET',
           headers: { 'Content-Type': 'application/json' },
         });
-
         if (!res.ok) throw new Error(t('config.guardrail.loadError'));
-
         const data = (await res.json()).data;
         setAliyunHasKey(data.length > 0);
         setAliyunAK(data[0]?.encrypted_access_key_id || '');
         setAliyunSK(data[0]?.encrypted_access_key_secret || '');
         const savedRegionName = data[0]?.region_name || '';
-        // Set default based on language if no saved value
-        if (savedRegionName) {
-          setRegionName(savedRegionName);
-        } else {
-          setRegionName(getRegionName('hangzhou', 'public'));
-        }
+        if (savedRegionName) setRegionName(savedRegionName);
+        else setRegionName(getRegionName('hangzhou', 'public'));
       } catch (err: any) {
         toast.error(t('config.guardrail.configLoadFailed'));
-      } finally {
-        setIsLoading(false);
       }
     };
-
     fetchConfig();
-  }, [language]); // Re-fetch when language changes to update region names
-  
-  // Save configuration
+  }, [language]);
+
   const handleSave = async () => {
     if (!aliyunAK || !aliyunSK) {
       toast.warning(t('config.guardrail.akSkRequired'));
@@ -125,28 +119,23 @@ export default function GuardrailConfig() {
     }
     try {
       setIsSaving(true);
-
       const update_ak = aliyunAK === '******' ? '' : aliyunAK;
       const update_sk = aliyunSK === '******' ? '' : aliyunSK;
-
       const res = await tenantFetch(`/api/config/guardrail`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-
         body: JSON.stringify({
           access_key_id: update_ak,
           access_key_secret: update_sk,
           region_name: regionName,
           endpoint: REGION_ENDPOINT_MAP.get(regionName),
-          region_id: REGION_ID_MAP.get(regionName)
+          region_id: REGION_ID_MAP.get(regionName),
         }),
       });
-
       if (!res.ok) {
         toast.error(t('config.guardrail.saveFailedToast'));
         throw new Error(t('config.guardrail.saveFailed'));
       }
-
       toast.success(t('config.guardrail.saveSuccess'));
     } catch (err: any) {
       toast.error(`${t('config.guardrail.saveFailed')}: ${err.message}`);
@@ -156,81 +145,78 @@ export default function GuardrailConfig() {
   };
 
   return (
-    <div id="search">
-      <div
-        className={
-          'transition-colors rounded-lg p-4 overflow-hidden duration-200'
-        }
-      >
-        <div className="flex flex-col items-center justify-center py-12 border-2 border-dashed border-gray-200 rounded-xl bg-gray-50">
-          <div className="flex gap-6 items-center">
-            <h2 className="text-xl font-medium text-gray-800">{t('config.guardrail.aliyunGuardrailTitle')}</h2> 
-            <Button variant="outline" className="h-6" asChild><a href="https://www.aliyun.com/product/content-moderation/guardrail">{t('config.guardrail.openUrl')}</a></Button>
+    <div id="guardrail" className="settings-page">
+      <div className="settings-page-header">
+        <h1 className="page-title">{t('config.guardrail.aliyunGuardrailTitle')}</h1>
+        <Button size="sm" onClick={handleSave} disabled={isSaving}>
+          {isSaving ? t('common.saving') : t('config.guardrail.saveConfig')}
+        </Button>
+      </div>
+
+      <div className="settings-page-content">
+        <div className="space-y-6">
+          <div>
+            <a
+              href="https://www.aliyun.com/product/content-moderation/guardrail"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+            >
+              {t('config.guardrail.openUrl')}
+              <ExternalLink className="w-3 h-3" />
+            </a>
           </div>
-          <div className="grid gap-4 py-4">
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="region" className="text-right">
-                {t('config.guardrail.selectRegion')}
-              </Label>
-              <div className="col-span-3 flex items-center">
-                <Select
-                  value={regionName}
-                  onValueChange={(value) =>
-                    setRegionName(value)
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder={t('config.guardrail.selectRegionPlaceholder')} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {REGION_NAMES.map((region_name) => (
-                      <SelectItem key={region_name} value={region_name}>
-                        {region_name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+
+          <div>
+            <div className="dialog-section-title mb-2">服务区域</div>
+            <div>
+              <label className="form-label">{t('config.guardrail.selectRegion')}</label>
+              <Select value={regionName} onValueChange={setRegionName}>
+                <SelectTrigger>
+                  <SelectValue placeholder={t('config.guardrail.selectRegionPlaceholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {REGION_NAMES.map((r) => (
+                    <SelectItem key={r} value={r}>
+                      {r}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="aliyun_ak" className="text-right">
-                {t('config.guardrail.accessKeyId')}
-              </Label>
-              <div className="col-span-3 flex items-center">
+          </div>
+
+          <div>
+            <div className="dialog-section-title mb-2">Aliyun 凭证</div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="aliyun_ak" className="form-label">
+                  {t('config.guardrail.accessKeyId')}
+                  <span className="required">*</span>
+                </label>
                 <Input
                   id="aliyun_ak"
                   defaultValue={aliyunHasKey ? '******' : ''}
                   type="password"
                   onChange={(e) => setAliyunAK(e.target.value)}
                   placeholder={t('config.guardrail.accessKeyIdPlaceholder')}
-                  className="col-span-3"
                 />
               </div>
-            </div>
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="aliyun_sk" className="text-right">
-                {t('config.guardrail.accessKeySecret')}
-              </Label>
-              <div className="col-span-3 flex items-center">
+              <div>
+                <label htmlFor="aliyun_sk" className="form-label">
+                  {t('config.guardrail.accessKeySecret')}
+                  <span className="required">*</span>
+                </label>
                 <Input
                   id="aliyun_sk"
                   defaultValue={aliyunHasKey ? '******' : ''}
                   type="password"
                   onChange={(e) => setAliyunSK(e.target.value)}
                   placeholder={t('config.guardrail.accessKeySecretPlaceholder')}
-                  className="col-span-3"
                 />
               </div>
             </div>
           </div>
-          <Button
-            onClick={handleSave}
-            disabled={isSaving}
-            className="mt-4 px-4 py-2 text-white rounded-lg transition-colors"
-          >
-            {isSaving ? t('common.saving') : t('config.guardrail.saveConfig')}
-          </Button>
-          {error && <p className="text-red-500 mt-2">{error}</p>}
         </div>
       </div>
     </div>

--- a/frontend/app/config/mcp/page.tsx
+++ b/frontend/app/config/mcp/page.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import {
-  TrashIcon,
-  SettingsIcon,
-  Edit,
-} from 'lucide-react';
+import { TrashIcon, Edit, Plus, PlugZap, MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -14,10 +10,8 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -33,8 +27,14 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { Checkbox } from '@/components/ui/checkbox';
-import { v4 as uuidv4 } from 'uuid';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { McpConfig } from './mcp';
 import { toast } from 'sonner';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
@@ -43,13 +43,13 @@ import { useI18n } from '@/app/providers/i18n';
 export default function McpConfigPage() {
   const { t } = useI18n();
 
-  const [isOpen, setIsOpen] = useState(false);
+  const [isAddOpen, setIsAddOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [editingConfig, setEditingConfig] = useState<McpConfig | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isEditLoading, setIsEditLoading] = useState(false);
 
-  const [addFormData, setAddFormData] = useState({
+  const emptyForm = {
     id: '',
     name: '',
     url: '',
@@ -57,20 +57,23 @@ export default function McpConfigPage() {
     auth_token: '',
     need_token: false,
     enabled: true,
-  });
+  };
+  const [addFormData, setAddFormData] = useState(emptyForm);
 
-  const [mcpconfigs, setMcpConfigs] = useState<Array<{
-    id: string;
-    name: string;
-    url: string;
-    type: string;
-    auth_token: string;
-    need_token: boolean;
-    enabled: boolean;
-  }>>([]);
+  const [mcpconfigs, setMcpConfigs] = useState<
+    Array<{
+      id: string;
+      name: string;
+      url: string;
+      type: string;
+      auth_token: string;
+      need_token: boolean;
+      enabled: boolean;
+    }>
+  >([]);
   const [mcploading, setMcpLoading] = useState(true);
   const { tenantFetch } = useTenantFetch();
-  // 提取 fetchConfigs 为可复用函数
+
   const fetchConfigs = useCallback(async () => {
     try {
       setMcpLoading(true);
@@ -94,37 +97,6 @@ export default function McpConfigPage() {
     setIsEditOpen(true);
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { id, value } = e.target;
-    const key = id.replace(/^mcp_/, '');
-    setAddFormData((prev) => ({ ...prev, [key]: value }));
-  };
-
-  const handleEditInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { id, value } = e.target;
-    const key = id.replace(/^edit_mcp_/, '');
-    setEditingConfig((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        [key]: value,
-      };
-    });
-  };
-
-  const handleEditInputChangeCheckbox = (isChecked: boolean, id?: string) => {
-    if (!id || !editingConfig) return;
-
-    const key = id.replace(/^edit_mcp_/, '');
-    setEditingConfig((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        [key]: isChecked,
-      };
-    });
-  };
-
   const handleToggleEnabled = async (id: string, enabled: boolean) => {
     try {
       const res = await tenantFetch(`/api/config/mcps/${id}`, {
@@ -132,16 +104,10 @@ export default function McpConfigPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ enabled: !enabled }),
       });
-
       if (!res.ok) throw new Error(t('config.mcp.updateStatusFailed'));
-
-      // Directly update local state to maintain data consistency
       setMcpConfigs((prev) =>
-        prev.map((config) =>
-          config.id === id ? { ...config, enabled: !enabled } : config
-        )
+        prev.map((c) => (c.id === id ? { ...c, enabled: !enabled } : c)),
       );
-
       toast.success(t(!enabled ? 'config.mcp.mcpEnabled' : 'config.mcp.mcpDisabled'));
     } catch (err: any) {
       toast.error(`${t('config.mcp.updateFailed')}: ${err.message}`);
@@ -149,400 +115,354 @@ export default function McpConfigPage() {
   };
 
   const addMCP = async () => {
-  try {
-    setIsLoading(true);
-    
-    // Use form data directly, without ID
-    const mcp_data = {
-      name: addFormData.name,
-      url: addFormData.url,
-      type: addFormData.type,
-      auth_token: addFormData.auth_token,
-      need_token: addFormData.auth_token ? true : false,
-      enabled: addFormData.enabled,
-    };
-    
-    const res = await tenantFetch(`/api/config/mcps`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(mcp_data),
-    });
-
-    if (!res.ok) {
-      const errorText = await res.text();
-      throw new Error(`${t('config.mcp.addError')}: ${res.status} ${errorText || res.statusText}`);
+    try {
+      setIsLoading(true);
+      const mcp_data = {
+        name: addFormData.name,
+        url: addFormData.url,
+        type: addFormData.type,
+        auth_token: addFormData.auth_token,
+        need_token: !!addFormData.auth_token,
+        enabled: addFormData.enabled,
+      };
+      const res = await tenantFetch(`/api/config/mcps`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(mcp_data),
+      });
+      if (!res.ok) {
+        const errorText = await res.text();
+        throw new Error(`${t('config.mcp.addError')}: ${res.status} ${errorText || res.statusText}`);
+      }
+      await fetchConfigs();
+      toast.success(t('config.mcp.addSuccess'));
+      setIsAddOpen(false);
+      setAddFormData(emptyForm);
+    } catch (err: any) {
+      toast.error(err.message || t('config.mcp.addFailed'));
+    } finally {
+      setIsLoading(false);
     }
+  };
 
-    // After success, re-fetch list to ensure ID consistency
-    await fetchConfigs();
-    toast.success(t('config.mcp.addSuccess'));
-
-    setIsOpen(false);
-
-    // Reset form data
-    setAddFormData({
-      id: uuidv4(),
-      name: '',
-      url: '',
-      type: 'sse',
-      auth_token: '',
-      need_token: false,
-      enabled: true,
-    });
-  } catch (err: any) {
-    const errorMessage = err.message || err.toString() || t('config.mcp.addFailed');
-    toast.error(errorMessage);
-  } finally {
-    setIsLoading(false);
-  }
-};
-
-const updatedMCP = async () => {
-  try {
-    if (!editingConfig) return;
-    setIsEditLoading(true);
-    
-    // Construct clean request body
-    const updateData: any = {
-      name: editingConfig.name,
-      url: editingConfig.url,
-      type: editingConfig.type,
-      enabled: editingConfig.enabled,
-    };
-
-    // Only send auth_token if it's not empty
-    if (editingConfig.auth_token && editingConfig.auth_token.trim() !== '') {
-      updateData.auth_token = editingConfig.auth_token;
-      updateData.need_token = true;
-    } else {
-      updateData.need_token = false;
+  const updatedMCP = async () => {
+    try {
+      if (!editingConfig) return;
+      setIsEditLoading(true);
+      const updateData: any = {
+        name: editingConfig.name,
+        url: editingConfig.url,
+        type: editingConfig.type,
+        enabled: editingConfig.enabled,
+      };
+      if (editingConfig.auth_token && editingConfig.auth_token.trim() !== '') {
+        updateData.auth_token = editingConfig.auth_token;
+        updateData.need_token = true;
+      } else {
+        updateData.need_token = false;
+      }
+      const res = await tenantFetch(`/api/config/mcps/${editingConfig.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updateData),
+      });
+      if (!res.ok) {
+        const errorText = await res.text();
+        throw new Error(`${t('config.mcp.updateError')}: ${res.status} ${errorText || res.statusText}`);
+      }
+      await fetchConfigs();
+      toast.success(t('config.mcp.updateSuccess'));
+      setIsEditOpen(false);
+    } catch (err: any) {
+      toast.error(`${t('config.mcp.updateError')}${err.message || t('config.mcp.updateFailed2')}`);
+    } finally {
+      setIsEditLoading(false);
     }
+  };
 
-    const res = await tenantFetch(`/api/config/mcps/${editingConfig.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(updateData),
-    });
-
-    if (!res.ok) {
-      const errorText = await res.text();
-      throw new Error(`${t('config.mcp.updateError')}: ${res.status} ${errorText || res.statusText}`);
-    }
-    
-    // After success, re-fetch list
-    await fetchConfigs();
-    
-    toast.success(t('config.mcp.updateSuccess'));
-    setIsEditOpen(false);
-  } catch (err: any) {
-    const errorMessage = err.message || err.toString() || t('config.mcp.updateFailed2');
-    toast.error(`${t('config.mcp.updateError')}${errorMessage}`);
-  } finally {
-    setIsEditLoading(false);
-  }
-};
   const removeMCP = async (id: string) => {
     try {
       const res = await tenantFetch(`/api/config/mcps/${id}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
-
-      if (!res.ok) {
-        throw new Error(t('config.mcp.deleteFailed'));
-      }
-      
+      if (!res.ok) throw new Error(t('config.mcp.deleteFailed'));
       toast.success(t('config.mcp.deleteSuccess'));
-
-
-      // Remove directly from local state
-      setMcpConfigs((prev) => prev.filter((config) => config.id !== id));
+      setMcpConfigs((prev) => prev.filter((c) => c.id !== id));
     } catch (err: any) {
       toast.error(`${t('config.mcp.deleteError')}${err.message}`);
     }
   };
 
   return (
-    <div id="mcp">
-      <div className={'transition-colors rounded-lg overflow-hidden'}>
-        <div className="flex flex-col items-center justify-center py-12 border-2 border-dashed border-gray-200 rounded-xl bg-gray-50">
-          {mcploading ? (
-            <div className="py-12 text-center">
-              <p className="text-gray-500">{t('config.mcp.loading')}</p>
-            </div>
-          ) : mcpconfigs.length === 0 ? (
-            <h3 className="text-lg font-medium text-gray-700 py-6">{t('config.mcp.noMcp')}</h3>
-          ) : (
-            <div className="gap-6 p-4 w-full">
-              <Table className="w-full table-fixed border bg-white rounded-md overflow-hidden">
-                <TableHeader className="bg-gray-100">
-                  <TableRow>
-                    <TableHead className="w-1/10">{t('config.mcp.mcpName')}</TableHead>
-                    <TableHead className="w-2/5">{t('config.mcp.mcpUrl')}</TableHead>
-                    <TableHead className="w-1/10">{t('config.mcp.mcpType')}</TableHead>
-                    <TableHead className="w-1/10">{t('config.mcp.isEnabled')}</TableHead>
-                    <TableHead className="w-1/5">{t('config.mcp.actions')}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {mcpconfigs.map((config) => (
-                    <TableRow key={config.id}>
-                      <TableCell>{config.name || ''}</TableCell>
-                      <TableCell>{config.url || ''}</TableCell>
-                      <TableCell>{config.type || ''}</TableCell>
-                      <TableCell>
-                        <Checkbox
-                          id={`enabled-${config.id}`}
-                          checked={config.enabled}
-                          onCheckedChange={(checked) => 
-                            handleToggleEnabled(config.id, config.enabled)
-                          }
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <Dialog open={isEditOpen} onOpenChange={setIsEditOpen}>
-                          <DialogTrigger asChild>
-                            <button
-                              className="text-black-500 hover:text-black-700 px-1 py-1"
-                              onClick={() => handleEditClick(config)}
-                            >
-                              <Edit className="w-4 h-4" />
-                            </button>
-                          </DialogTrigger>
-                          <DialogContent className="sm:max-w-[425px]">
-                            <DialogHeader>
-                              <DialogTitle>{t('config.mcp.editMcp')}</DialogTitle>
-                              <DialogDescription>
-                                {t('config.mcp.editDialogDesc')}
-                              </DialogDescription>
-                            </DialogHeader>
-                            <div className="grid gap-4 py-4">
-                              <div className="grid grid-cols-4 items-center gap-4">
-                                <Label
-                                  htmlFor="edit_mcp_name"
-                                  className="text-right"
-                                >
-                                  {t('config.mcp.mcpNameLabel')}
-                                </Label>
-                                <Input
-                                  id="edit_mcp_name"
-                                  value={editingConfig?.name || ''}
-                                  onChange={handleEditInputChange}
-                                  className="col-span-3"
-                                />
-                              </div>
-                              <div className="grid grid-cols-4 items-center gap-4">
-                                <Label
-                                  htmlFor="edit_mcp_url"
-                                  className="text-right"
-                                >
-                                  {t('config.mcp.mcpUrlLabel')}
-                                </Label>
-                                <Input
-                                  id="edit_mcp_url"
-                                  value={editingConfig?.url || ''}
-                                  onChange={handleEditInputChange}
-                                  className="col-span-3"
-                                />
-                              </div>
-                              <div className="grid grid-cols-4 items-center gap-4">
-                                <Label
-                                  htmlFor="edit_mcp_type"
-                                  className="text-right"
-                                >
-                                  {t('config.mcp.mcpTypeLabel')}
-                                </Label>
-                                <Select
-                                  value={editingConfig?.type || 'streamable_http'}
-                                  onValueChange={(value) =>
-                                    setEditingConfig((prev) =>
-                                      prev ? { ...prev, type: value } : prev
-                                    )
-                                  }
-                                >
-                                  <SelectTrigger className="col-span-3">
-                                    <SelectValue placeholder={t('config.mcp.mcpTypePlaceholder')} />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    <SelectItem value="streamable_http">
-                                      <span suppressHydrationWarning>{t('config.mcp.streamableHttp')}</span>
-                                    </SelectItem>
-                                    <SelectItem value="sse">
-                                      <span suppressHydrationWarning>{t('config.mcp.sse')}</span>
-                                    </SelectItem>
-                                  </SelectContent>
-                                </Select>
-                              </div>
-                              <div className="grid grid-cols-7 items-center gap-4">
-                                <Label
-                                  htmlFor="edit_mcp_auth_token"
-                                  className="text-right col-span-2"
-                                >
-                                  {t('config.mcp.bearerToken')}
-                                </Label>
-                                <Input
-                                  id="edit_mcp_auth_token"
-                                  type="password"
-                                  value={
-                                    editingConfig?.auth_token || ''
-                                  }
-                                  onChange={handleEditInputChange}
-                                  className="col-span-5"
-                                />
-                              </div>
-                              <div className="grid grid-cols-4 items-center gap-4">
-                                <Label
-                                  htmlFor="edit_mcp_enabled"
-                                  className="text-right"
-                                >
-                                  {t('config.mcp.isEnabled')}
-                                </Label>
-                                <Checkbox
-                                  id="edit_mcp_enabled"
-                                  checked={editingConfig?.enabled || false}
-                                  onCheckedChange={(checkedState) => {
-                                    const isChecked = checkedState === true;
-                                    handleEditInputChangeCheckbox(
-                                      isChecked,
-                                      'edit_mcp_enabled',
-                                    );
-                                  }}
-                                  className="col-span-3"
-                                />
-                              </div>
-                            </div>
-                            <DialogFooter>
-                              <Button
-                                onClick={updatedMCP}
-                                type="submit"
-                                disabled={isEditLoading}
-                              >
-                                {isEditLoading ? t('config.mcp.submitting') : t('config.mcp.editButton')}
-                              </Button>
-                            </DialogFooter>
-                          </DialogContent>
-                        </Dialog>
-
-                        <button
-                          onClick={() => removeMCP(config.id)}
-                          className="text-red-500 hover:text-red-700 px-4 py-1"
-                        >
-                          <TrashIcon className="w-4 h-4" />
-                        </button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-          <SettingsIcon className="w-10 h-6 text-gray-400 mb-4" />
-          <p className="text-gray-500 mt-1">{t('config.mcp.clickToAddNew')}</p>
-          <Dialog open={isOpen} onOpenChange={setIsOpen}>
-            <DialogTrigger asChild>
-              <Button className="mt-4 px-4 py-2 text-white rounded-lg transition-colors">
-                {t('config.mcp.addMcp')}
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-[425px]">
-              <DialogHeader>
-                <DialogTitle>{t('config.mcp.addMcp')}</DialogTitle>
-                <DialogDescription>
-                  {t('config.mcp.addDialogDesc')}
-                </DialogDescription>
-              </DialogHeader>
-              <div className="grid gap-4 py-4">
-                <div className="grid grid-cols-4 items-center gap-4">
-                  <Label htmlFor="mcp_name" className="text-right">
-                    {t('config.mcp.mcpNameLabel')}
-                    <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    id="mcp_name"
-                    placeholder="MCP"
-                    value={addFormData.name}
-                    onChange={handleInputChange}
-                    className="col-span-3"
-                  />
-                </div>
-                <div className="grid grid-cols-4 items-center gap-4">
-                  <Label htmlFor="mcp_url" className="text-right">
-                    {t('config.mcp.mcpUrlLabel')}
-                    <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    id="mcp_url"
-                    placeholder="URL"
-                    value={addFormData.url}
-                    onChange={handleInputChange}
-                    className="col-span-3"
-                  />
-                </div>
-                <div className="grid grid-cols-4 items-center gap-4">
-                  <Label htmlFor="mcp_type" className="text-right">
-                    {t('config.mcp.mcpTypeLabel')}
-                    <span className="text-destructive">*</span>
-                  </Label>
-                  <Select
-                    value={addFormData.type}
-                    onValueChange={(value) =>
-                      setAddFormData((prev) => ({ ...prev, type: value }))
-                    }
-                  >
-                    <SelectTrigger className="col-span-3">
-                      <SelectValue placeholder={t('config.mcp.mcpTypePlaceholder')} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="streamable_http">
-                        <span suppressHydrationWarning>{t('config.mcp.streamableHttp')}</span>
-                      </SelectItem>
-                      <SelectItem value="sse">
-                        <span suppressHydrationWarning>{t('config.mcp.sse')}</span>
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="grid grid-cols-7 items-center gap-4">
-                  <Label
-                    htmlFor="mcp_auth_token"
-                    className="text-right col-span-2"
-                  >
-                    {t('config.mcp.bearerToken')}
-                  </Label>
-                  <Input
-                    id="mcp_auth_token"
-                    type="password"
-                    placeholder={t('config.mcp.bearerTokenPlaceholder')}
-                    value={addFormData.auth_token}
-                    onChange={handleInputChange}
-                    className="col-span-5"
-                  />
-                </div>
-                <div className="grid grid-cols-4 items-center gap-4">
-                  <Label htmlFor="mcp_enabled" className="text-right">
-                    {t('config.mcp.defaultEnabled')}
-                  </Label>
-                  <Checkbox
-                    id="mcp_enabled"
-                    checked={addFormData.enabled}
-                    onCheckedChange={(checked) => 
-                      setAddFormData(prev => ({ ...prev, enabled: checked === true }))
-                    }
-                    className="col-span-3"
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button onClick={addMCP} type="submit" disabled={isLoading}>
-                  {isLoading ? t('config.mcp.submitting') : t('config.mcp.addButton')}
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        </div>
+    <div id="mcp" className="settings-page">
+      <div className="settings-page-header">
+        <h1 className="page-title">
+          MCP <span className="text-xs text-muted-foreground font-normal ml-1">· {mcpconfigs.length}</span>
+        </h1>
+        <Button size="sm" onClick={() => { setAddFormData(emptyForm); setIsAddOpen(true); }}>
+          <Plus className="w-4 h-4" />
+          {t('config.mcp.addMcp')}
+        </Button>
       </div>
+
+      <div className="settings-page-content">
+        {mcploading ? (
+          <div className="py-12 text-center">
+            <p className="text-sm text-muted-foreground">{t('config.mcp.loading')}</p>
+          </div>
+        ) : mcpconfigs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <PlugZap className="w-12 h-12 text-muted-foreground/40 mb-3" />
+            <p className="text-sm text-muted-foreground mb-3">{t('config.mcp.noMcp')}</p>
+            <Button size="sm" variant="outline" onClick={() => { setAddFormData(emptyForm); setIsAddOpen(true); }}>
+              <Plus className="w-4 h-4" />
+              {t('config.mcp.addMcp')}
+            </Button>
+          </div>
+        ) : (
+          <Table className="table-modern w-full border rounded-md overflow-hidden">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[20%]">{t('config.mcp.mcpName')}</TableHead>
+                <TableHead>{t('config.mcp.mcpUrl')}</TableHead>
+                <TableHead className="w-[140px]">{t('config.mcp.mcpType')}</TableHead>
+                <TableHead className="w-[90px] text-center">{t('config.mcp.isEnabled')}</TableHead>
+                <TableHead className="w-[60px] text-right pr-4">{t('config.mcp.actions')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {mcpconfigs.map((config) => (
+                <TableRow key={config.id}>
+                  <TableCell className="font-medium text-sm">{config.name || ''}</TableCell>
+                  <TableCell className="text-xs font-mono text-muted-foreground truncate max-w-0">
+                    <span title={config.url}>{config.url || ''}</span>
+                  </TableCell>
+                  <TableCell>
+                    <Badge className="badge-tech text-[10.5px] py-0">{config.type || ''}</Badge>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <Switch
+                      checked={config.enabled}
+                      onCheckedChange={() => handleToggleEnabled(config.id, config.enabled)}
+                    />
+                  </TableCell>
+                  <TableCell className="text-right pr-2">
+                    <DropdownMenu modal={false}>
+                      <DropdownMenuTrigger asChild>
+                        <button type="button" className="icon-action-btn" aria-label="More">
+                          <MoreHorizontal className="w-4 h-4" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="menu-compact">
+                        <DropdownMenuItem onSelect={() => handleEditClick(config)}>
+                          <Edit />
+                          {t('common.edit') || 'Edit'}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="text-destructive focus:text-destructive"
+                          onSelect={() => removeMCP(config.id)}
+                        >
+                          <TrashIcon />
+                          {t('common.delete') || 'Delete'}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+
+      {/* Add Dialog */}
+      <Dialog open={isAddOpen} onOpenChange={setIsAddOpen}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <PlugZap className="w-4 h-4 text-primary" />
+              {t('config.mcp.addMcp')}
+            </DialogTitle>
+            <DialogDescription>{t('config.mcp.addDialogDesc')}</DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div>
+              <label htmlFor="mcp_name" className="form-label">
+                {t('config.mcp.mcpNameLabel')}<span className="required">*</span>
+              </label>
+              <Input
+                id="mcp_name"
+                placeholder="MCP"
+                value={addFormData.name}
+                onChange={(e) => setAddFormData((p) => ({ ...p, name: e.target.value }))}
+              />
+            </div>
+            <div>
+              <label htmlFor="mcp_url" className="form-label">
+                {t('config.mcp.mcpUrlLabel')}<span className="required">*</span>
+              </label>
+              <Input
+                id="mcp_url"
+                placeholder="URL"
+                value={addFormData.url}
+                onChange={(e) => setAddFormData((p) => ({ ...p, url: e.target.value }))}
+              />
+            </div>
+            <div>
+              <label htmlFor="mcp_type" className="form-label">
+                {t('config.mcp.mcpTypeLabel')}<span className="required">*</span>
+              </label>
+              <Select
+                value={addFormData.type}
+                onValueChange={(v) => setAddFormData((p) => ({ ...p, type: v }))}
+              >
+                <SelectTrigger id="mcp_type">
+                  <SelectValue placeholder={t('config.mcp.mcpTypePlaceholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="streamable_http">
+                    <span suppressHydrationWarning>{t('config.mcp.streamableHttp')}</span>
+                  </SelectItem>
+                  <SelectItem value="sse">
+                    <span suppressHydrationWarning>{t('config.mcp.sse')}</span>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label htmlFor="mcp_auth_token" className="form-label">
+                {t('config.mcp.bearerToken')}
+              </label>
+              <Input
+                id="mcp_auth_token"
+                type="password"
+                placeholder={t('config.mcp.bearerTokenPlaceholder')}
+                value={addFormData.auth_token}
+                onChange={(e) => setAddFormData((p) => ({ ...p, auth_token: e.target.value }))}
+              />
+            </div>
+            <div className="form-row-inline">
+              <div className="form-row-inline-label">
+                <span className="title">{t('config.mcp.defaultEnabled')}</span>
+                <span className="hint">启用后可在对话中使用</span>
+              </div>
+              <Switch
+                checked={addFormData.enabled}
+                onCheckedChange={(v) => setAddFormData((p) => ({ ...p, enabled: v }))}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsAddOpen(false)}>
+              {t('common.cancel') || 'Cancel'}
+            </Button>
+            <Button onClick={addMCP} disabled={isLoading}>
+              {isLoading ? t('config.mcp.submitting') : t('config.mcp.addButton')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog open={isEditOpen} onOpenChange={setIsEditOpen}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <PlugZap className="w-4 h-4 text-primary" />
+              {t('config.mcp.editMcp')}
+            </DialogTitle>
+            <DialogDescription>{t('config.mcp.editDialogDesc')}</DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div>
+              <label htmlFor="edit_mcp_name" className="form-label">
+                {t('config.mcp.mcpNameLabel')}
+              </label>
+              <Input
+                id="edit_mcp_name"
+                value={editingConfig?.name || ''}
+                onChange={(e) =>
+                  setEditingConfig((prev) => (prev ? { ...prev, name: e.target.value } : prev))
+                }
+              />
+            </div>
+            <div>
+              <label htmlFor="edit_mcp_url" className="form-label">
+                {t('config.mcp.mcpUrlLabel')}
+              </label>
+              <Input
+                id="edit_mcp_url"
+                value={editingConfig?.url || ''}
+                onChange={(e) =>
+                  setEditingConfig((prev) => (prev ? { ...prev, url: e.target.value } : prev))
+                }
+              />
+            </div>
+            <div>
+              <label htmlFor="edit_mcp_type" className="form-label">
+                {t('config.mcp.mcpTypeLabel')}
+              </label>
+              <Select
+                value={editingConfig?.type || 'streamable_http'}
+                onValueChange={(v) =>
+                  setEditingConfig((prev) => (prev ? { ...prev, type: v } : prev))
+                }
+              >
+                <SelectTrigger id="edit_mcp_type">
+                  <SelectValue placeholder={t('config.mcp.mcpTypePlaceholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="streamable_http">
+                    <span suppressHydrationWarning>{t('config.mcp.streamableHttp')}</span>
+                  </SelectItem>
+                  <SelectItem value="sse">
+                    <span suppressHydrationWarning>{t('config.mcp.sse')}</span>
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label htmlFor="edit_mcp_auth_token" className="form-label">
+                {t('config.mcp.bearerToken')}
+              </label>
+              <Input
+                id="edit_mcp_auth_token"
+                type="password"
+                value={editingConfig?.auth_token || ''}
+                onChange={(e) =>
+                  setEditingConfig((prev) =>
+                    prev ? { ...prev, auth_token: e.target.value } : prev,
+                  )
+                }
+              />
+            </div>
+            <div className="form-row-inline">
+              <div className="form-row-inline-label">
+                <span className="title">{t('config.mcp.isEnabled')}</span>
+              </div>
+              <Switch
+                checked={editingConfig?.enabled || false}
+                onCheckedChange={(v) =>
+                  setEditingConfig((prev) => (prev ? { ...prev, enabled: v } : prev))
+                }
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsEditOpen(false)}>
+              {t('common.cancel') || 'Cancel'}
+            </Button>
+            <Button onClick={updatedMCP} disabled={isEditLoading}>
+              {isEditLoading ? t('config.mcp.submitting') : t('config.mcp.editButton')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/app/config/model/embedding/modelDialog.tsx
+++ b/frontend/app/config/model/embedding/modelDialog.tsx
@@ -10,8 +10,6 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Alert, AlertTitle } from '@/components/ui/alert';
 import { AlertCircleIcon } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
@@ -27,8 +25,8 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
+import { cn } from '@/lib/utils';
 
-// Component props
 interface EmbeddingModelDialogProps {
   isAdd: boolean;
   isOpen: boolean;
@@ -37,7 +35,6 @@ interface EmbeddingModelDialogProps {
   onSaveSuccess: (emb: EmbConfig) => void;
 }
 
-// Model data type
 export interface EmbConfig {
   id: string;
   model_id: string;
@@ -59,10 +56,15 @@ export const EmbeddingModelDialog: FC<EmbeddingModelDialogProps> = ({
   onSaveSuccess,
 }) => {
   const [emb, setEmb] = useState<EmbConfig>(embConfig);
-  const [error, setError] = useState<string | null>(null);
   const [saveErrorMsg, setSaveErrorMsg] = useState('');
   const { tenantFetch } = useTenantFetch();
   const { t } = useI18n();
+
+  // Freeze isAdd while the dialog is closing (prevents title flicker).
+  const [displayIsAdd, setDisplayIsAdd] = useState(isAdd);
+  useEffect(() => {
+    if (isOpen) setDisplayIsAdd(isAdd);
+  }, [isOpen, isAdd]);
 
   useEffect(() => {
     setEmb(embConfig);
@@ -76,8 +78,6 @@ export const EmbeddingModelDialog: FC<EmbeddingModelDialogProps> = ({
     setSaveErrorMsg('');
     const is_api_model = emb.type != 'local';
     if (emb.dimension === 0) emb.dimension = undefined;
-
-    console.log('handleSubmit', emb, is_api_model);
 
     if (
       is_api_model &&
@@ -101,7 +101,6 @@ export const EmbeddingModelDialog: FC<EmbeddingModelDialogProps> = ({
       : `/api/config/embeddings/${emb.id}`;
     const updateMethod = isAdd ? 'POST' : 'PUT';
     if (emb.api_key === '******') emb.api_key = '';
-    console.log('updateMethod', isAdd, updateMethod, submit_url, emb);
     try {
       const res = await tenantFetch(submit_url, {
         method: updateMethod,
@@ -121,206 +120,205 @@ export const EmbeddingModelDialog: FC<EmbeddingModelDialogProps> = ({
     }
   };
 
-  // Reset form when dialog closes
   const handleDialogClose = (open: boolean) => {
     setIsOpen(open);
-    if (!open) {
-      setError(null);
-      setSaveErrorMsg('');
-    }
+    if (!open) setSaveErrorMsg('');
   };
 
-  // Manage confirmation dialog open state
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-
-  // Temporarily store user's target state
   const [pendingState, setPendingState] = useState<boolean | null>(null);
+
+  const isApiLike = emb?.type === 'openai_like';
 
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogClose}>
-      <DialogContent className="sm:max-w-[700px]">
-        {error && <div className="text-red-500 mb-4">{error}</div>}
+      <DialogContent className="sm:max-w-[560px]">
         <DialogHeader>
-          <DialogTitle>{isAdd ? t('config.model.addModel') : t('config.model.editModel')}</DialogTitle>
-          <DialogDescription>{t('config.model.fillModelConfig')}</DialogDescription>
+          <DialogTitle className="flex items-center gap-2">
+            <span className="type-corner-badge type-embedding">EMB</span>
+            {displayIsAdd ? '添加 Embedding 模型' : '编辑 Embedding 模型'}
+          </DialogTitle>
+          <DialogDescription>
+            填写 Embedding（向量）模型的配置信息后保存
+          </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-4 py-2">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="model_id" className="text-right">
-              {t('config.model.modelId')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="model_id"
-              placeholder={t('config.model.modelIdPlaceholder')}
-              value={emb?.model_id ?? ''}
-              onChange={(e) =>
-                setEmb((prev) => ({ ...prev, model_id: e.target.value }))
-              }
-              className="col-span-3"
-            />
-          </div>
-        </div>
-        {emb?.type === 'openai_like' && (
-          <div className="grid grid-cols-4 items-center gap-4 py-2">
-            <Label htmlFor="endpoint" className="text-right">
-              {t('config.model.endpointUrl')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <div className="col-span-3">
-              <input
-                id="endpoint"
-                list="endpoint_options"
-                placeholder={t('config.model.endpointPlaceholder')}
-                value={emb?.endpoint ?? ''}
-                onChange={(e) =>
-                  setEmb((prev) => ({ ...prev, endpoint: e.target.value }))
-                }
-                className="w-full border border-gray-300 rounded-md p-2 text-sm"
-              />
-              <datalist id="endpoint_options">
-                <option value="https://api.openai.com/v1">OpenAI</option>
-                <option value="https://dashscope.aliyuncs.com/compatible-mode/v1">
-                  {t('config.model.qwenModel')}
-                </option>
-              </datalist>
-            </div>
-          </div>
-        )}
-        {emb?.type === 'openai_like' && (
-          <div className="grid grid-cols-4 items-center gap-4 py-2">
-            <Label htmlFor="api_key" className="text-right">
-              {t('config.model.apiKey')}
-              <span className="text-destructive">*</span>
-            </Label>
-            {isAdd ? (
-              <Input
-                id="api_key"
-                type="password"
-                placeholder={t('config.model.apiKeyPlaceholder')}
-                value={emb?.api_key ?? ''}
-                onChange={(e) =>
-                  setEmb((prev) => ({ ...prev, api_key: e.target.value }))
-                }
-                className="col-span-3"
-              />
-            ) : (
-              <Input
-                id="api_key"
-                type="password"
-                placeholder={t('config.model.apiKeyPlaceholder')}
-                value={emb?.api_key || '******'}
-                onChange={(e) =>
-                  setEmb((prev) => ({ ...prev, api_key: e.target.value }))
-                }
-                className="col-span-3"
-              />
-            )}
-          </div>
-        )}
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="model_name" className="text-right">
-              {t('config.model.modelName')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="model_name"
-              placeholder={t('config.model.modelNamePlaceholder')}
-              value={emb?.model_name ?? ''}
-              onChange={(e) =>
-                setEmb((prev) => ({ ...prev, model_name: e.target.value }))
-              }
-              className="col-span-3"
-            />
-          </div>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="model_type" className="text-right">
+        <div className="space-y-4 py-2">
+          {/* Type selector — segmented */}
+          <div>
+            <label className="form-label">
               {t('config.model.modelType')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <RadioGroup
-              className="flex flex-row gap-6 col-span-3"
-              value={emb?.type}
-              onValueChange={(value) => setEmb({ ...emb, type: value })}
-            >
-              <div className="flex items-center gap-3">
-                <RadioGroupItem value="local" />
-                <Label>{t('config.model.localHosted')}</Label>
-              </div>
-              <div className="flex items-center gap-3">
-                <RadioGroupItem value="openai_like" />
-                <Label>{t('config.model.apiOpenaiLike')}</Label>
-              </div>
-            </RadioGroup>
+              <span className="required">*</span>
+            </label>
+            <div className="grid grid-cols-2 gap-2 p-1 rounded-lg bg-muted">
+              <button
+                type="button"
+                className={cn(
+                  'px-3 py-2 text-sm rounded-md transition-all',
+                  emb?.type === 'local'
+                    ? 'bg-background shadow-sm font-medium text-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                onClick={() => setEmb({ ...emb, type: 'local' })}
+              >
+                {t('config.model.localHosted')}
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  'px-3 py-2 text-sm rounded-md transition-all',
+                  emb?.type === 'openai_like'
+                    ? 'bg-background shadow-sm font-medium text-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                onClick={() => setEmb({ ...emb, type: 'openai_like' })}
+              >
+                {t('config.model.apiOpenaiLike')}
+              </button>
+            </div>
           </div>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4 py-2">
-            <Label htmlFor="dimension" className="text-right">
-              {t('config.model.vectorDimension')}
-            </Label>
-            <div className="col-span-3">
-              <Input
-                id="dimension"
-                type="number"
-                placeholder={t('config.model.vectorDimensionPlaceholder')}
-                defaultValue={emb?.dimension}
-                onChange={(e) =>
-                  setEmb({
-                    ...emb,
-                    dimension: Number(e.target.value),
-                  })
-                }
+
+          {/* Basic section */}
+          <div>
+            <div className="dialog-section-title">Basic</div>
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="model_id" className="form-label">
+                  {t('config.model.modelId')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="model_id"
+                  placeholder={t('config.model.modelIdPlaceholder')}
+                  value={emb?.model_id ?? ''}
+                  onChange={(e) => setEmb((prev) => ({ ...prev, model_id: e.target.value }))}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="model_name" className="form-label">
+                  {t('config.model.modelName')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="model_name"
+                  placeholder={t('config.model.modelNamePlaceholder')}
+                  value={emb?.model_name ?? ''}
+                  onChange={(e) => setEmb((prev) => ({ ...prev, model_name: e.target.value }))}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Endpoint section (only for API-like) */}
+          {isApiLike && (
+            <div>
+              <div className="dialog-section-title">Endpoint</div>
+              <div className="space-y-3">
+                <div>
+                  <label htmlFor="endpoint" className="form-label">
+                    {t('config.model.endpointUrl')}
+                    <span className="required">*</span>
+                  </label>
+                  <Input
+                    id="endpoint"
+                    list="endpoint_options"
+                    placeholder={t('config.model.endpointPlaceholder')}
+                    value={emb?.endpoint ?? ''}
+                    onChange={(e) => setEmb((prev) => ({ ...prev, endpoint: e.target.value }))}
+                  />
+                  <datalist id="endpoint_options">
+                    <option value="https://api.openai.com/v1">OpenAI</option>
+                    <option value="https://dashscope.aliyuncs.com/compatible-mode/v1">
+                      {t('config.model.qwenModel')}
+                    </option>
+                  </datalist>
+                </div>
+
+                <div>
+                  <label htmlFor="api_key" className="form-label">
+                    {t('config.model.apiKey')}
+                    <span className="required">*</span>
+                  </label>
+                  <Input
+                    id="api_key"
+                    type="password"
+                    placeholder={t('config.model.apiKeyPlaceholder')}
+                    value={isAdd ? (emb?.api_key ?? '') : (emb?.api_key || '******')}
+                    onChange={(e) => setEmb((prev) => ({ ...prev, api_key: e.target.value }))}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Advanced section */}
+          <div>
+            <div className="dialog-section-title">Advanced</div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="dimension" className="form-label">
+                  {t('config.model.vectorDimension')}
+                  {!isApiLike && <span className="required">*</span>}
+                </label>
+                <Input
+                  id="dimension"
+                  type="number"
+                  placeholder={t('config.model.vectorDimensionPlaceholder')}
+                  value={emb?.dimension ?? ''}
+                  onChange={(e) =>
+                    setEmb({ ...emb, dimension: Number(e.target.value) || undefined })
+                  }
+                />
+              </div>
+
+              <div>
+                <label htmlFor="embed_batch_size" className="form-label">
+                  {t('config.model.vectorBatchSize')}
+                </label>
+                <Input
+                  id="embed_batch_size"
+                  type="number"
+                  placeholder={t('config.model.vectorBatchSizePlaceholder')}
+                  value={emb?.embed_batch_size ?? ''}
+                  onChange={(e) =>
+                    setEmb({ ...emb, embed_batch_size: Number(e.target.value) })
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="form-row-inline mt-3">
+              <div className="form-row-inline-label">
+                <span className="title">{t('config.model.defaultVectorModel')}</span>
+                <span className="hint">作为知识库默认的 Embedding 模型</span>
+              </div>
+              <Switch
+                checked={emb.is_default}
+                onCheckedChange={(checked) => {
+                  if (emb.is_default === checked) return;
+                  setPendingState(checked);
+                  setIsDialogOpen(true);
+                }}
               />
             </div>
           </div>
+
+          {saveErrorMsg !== '' && (
+            <Alert className="bg-destructive/10 dark:bg-destructive/20 border-none">
+              <AlertCircleIcon className="h-4 w-4 !text-destructive" />
+              <AlertTitle>{saveErrorMsg}</AlertTitle>
+            </Alert>
+          )}
         </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4 py-2">
-            <Label htmlFor="embed_batch_size" className="text-right">
-              {t('config.model.vectorBatchSize')}
-            </Label>
-            <Input
-              id="embed_batch_size"
-              type="number"
-              placeholder={t('config.model.vectorBatchSizePlaceholder')}
-              defaultValue={emb?.embed_batch_size || 'null'}
-              onChange={(e) =>
-                setEmb({
-                  ...emb,
-                  embed_batch_size: Number(e.target.value),
-                })
-              }
-              className="col-span-3"
-            />
-          </div>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4 py-2">
-            <Label htmlFor="embed_batch_size" className="text-right">
-              {t('config.model.defaultVectorModel')}
-            </Label>
-            <Switch
-              checked={emb.is_default}
-              className="justify-start rounded-full transition-color"
-              onCheckedChange={(checked) => {
-                const targetState = checked;
-                if (emb.is_default === targetState) return;
-                setPendingState(targetState);
-                setIsDialogOpen(true);
-              }}
-            />
-          </div>
-        </div>
-        {/* 确认对话框 */}
+
+        {/* Confirm default change */}
         <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>{t('config.model.confirmChangeDefaultModel')}</AlertDialogTitle>
+              <AlertDialogTitle>
+                {t('config.model.confirmChangeDefaultModel')}
+              </AlertDialogTitle>
               <AlertDialogDescription>
                 {pendingState
                   ? t('config.model.setAsDefaultWarning')
@@ -331,10 +329,7 @@ export const EmbeddingModelDialog: FC<EmbeddingModelDialogProps> = ({
               <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
               <AlertDialogAction
                 onClick={() => {
-                  setEmb({
-                    ...emb,
-                    is_default: pendingState || false,
-                  });
+                  setEmb({ ...emb, is_default: pendingState || false });
                   setIsDialogOpen(false);
                 }}
               >
@@ -344,14 +339,13 @@ export const EmbeddingModelDialog: FC<EmbeddingModelDialogProps> = ({
           </AlertDialogContent>
         </AlertDialog>
 
-        <DialogFooter className="flex flex-col gap-4">
-          {saveErrorMsg !== '' && (
-            <Alert className="bg-destructive/10 dark:bg-destructive/20 border-none">
-              <AlertCircleIcon className="h-4 w-4 !text-destructive" />
-              <AlertTitle>{saveErrorMsg}</AlertTitle>
-            </Alert>
-          )}
-          <Button onClick={handleSubmit}>{isAdd ? t('config.model.create') : t('common.save')}</Button>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setIsOpen(false)}>
+            {t('common.cancel') || 'Cancel'}
+          </Button>
+          <Button onClick={handleSubmit}>
+            {displayIsAdd ? '创建 Embedding 模型' : t('common.save')}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/app/config/model/embedding/page.tsx
+++ b/frontend/app/config/model/embedding/page.tsx
@@ -7,19 +7,20 @@ import {
   AlertCircleIcon,
   Loader2,
   CheckCircle,
+  Plus,
+  Layers,
+  MoreHorizontal,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardFooter,
-} from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { EmbeddingModelDialog, EmbConfig } from '@/app/config/model/embedding/modelDialog';
-import { PaginationComponent } from '@/components/customized/pagination/pagination-component';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
@@ -40,13 +41,7 @@ export default function EmbConfigPage() {
 
   const [editEmbConfig, setEditEmbConfig] = useState<EmbConfig>(newembconfig);
   const [embconfigs, setEmbConfigs] = useState<EmbConfig[]>([]);
-  const [modelloading, setModelLoading] = useState(true);
-  const [modelerror, setModelError] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
-
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const modelSizePerPage = 8;
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
@@ -55,207 +50,189 @@ export default function EmbConfigPage() {
   useEffect(() => {
     const fetchModelConfigs = async () => {
       try {
-        const res = await tenantFetch(
-          `/api/config/embeddings?page=${page}&size=${modelSizePerPage}`,
-        );
+        const res = await tenantFetch(`/api/config/embeddings?page=1&size=100`);
         if (!res.ok) throw new Error(t('config.model.fetchModelListFailed'));
         const json_data = await res.json();
-        const data = json_data.data.items;
-        setEmbConfigs(data);
-        setTotalPages(json_data.data.pages);
+        setEmbConfigs(json_data.data.items || []);
       } catch (err: any) {
-        setModelError(err || t('config.model.loadFailed'));
-      } finally {
-        setModelLoading(false);
+        // swallow
       }
     };
     fetchModelConfigs();
-  }, [page, embconfigs.length, isEditOpen]);
+  }, [embconfigs.length, isEditOpen]);
 
-  const handleCreateSuccess = (llmConfig: EmbConfig) => {
-    setEmbConfigs((prev) => [...prev, llmConfig]);
-    console.log(t('config.model.createModelSuccess'), llmConfig);
+  const handleCreateSuccess = (config: EmbConfig) => {
+    setEmbConfigs((prev) => [...prev, config]);
     setEditEmbConfig(newembconfig);
   };
 
-  const handleSaveSuccess = (llmConfig: EmbConfig) => {
-    setEmbConfigs((prev) =>
-      prev.map((config) => (config.id === llmConfig.id ? llmConfig : config)),
-    );
-    console.log(t('config.model.editModelSuccess'), llmConfig);
+  const handleSaveSuccess = (config: EmbConfig) => {
+    setEmbConfigs((prev) => prev.map((c) => (c.id === config.id ? config : c)));
     setEditEmbConfig(newembconfig);
   };
 
-  const handlePageChange = (newPage: number) => {
-    if (newPage < 1 || newPage > totalPages) return;
-    setPage(newPage);
-  };
-
-  const removeModel = async (id: string, model_type: string) => {
+  const removeModel = async (id: string) => {
     setErrorMsg('');
     try {
-      console.log('removeModel: id: ', id, 'model_type: ', model_type);
-
-      const res = await tenantFetch(`/api/config/${model_type}/${id}`, {
+      const res = await tenantFetch(`/api/config/embeddings/${id}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
 
       if (!res.ok) {
-        setErrorMsg(t('config.model.deleteModelFailed', { modelType: model_type }));
+        setErrorMsg(t('config.model.deleteModelFailed', { modelType: 'Embedding' }));
         return;
       }
-
-      // Delete success, update local state
-      if (model_type === 'embeddings') {
-        setEmbConfigs((prev) => prev.filter((config) => config.id !== id));
-      }
+      setEmbConfigs((prev) => prev.filter((config) => config.id !== id));
     } catch (err: any) {
       setErrorMsg(t('config.model.deleteFailed'));
     }
   };
 
-  return (
-    <div id="llm">
-      <div className="grid grid-cols-1 pb-8">
-        <Button
-          onClick={() => {
-            setIsCreateOpen(true);
-            setEditEmbConfig(newembconfig);
-          }}
-        >
-          {t('config.model.addEmbeddingModel')}
-        </Button>
-        <EmbeddingModelDialog
-          isAdd={isCreateOpen ? true : false}
-          isOpen={isEditOpen || isCreateOpen}
-          setIsOpen={(open: boolean) => {
-            if (!open) {
-              setEditEmbConfig(newembconfig);
-            }
-            setIsEditOpen(open);
-            setIsCreateOpen(open);
-          }}
-          embConfig={editEmbConfig || newembconfig}
-          onSaveSuccess={(emb: EmbConfig) => {
-            if (isCreateOpen) {
-              handleCreateSuccess(emb);
-            } else {
-              handleSaveSuccess(emb);
-            }
-          }}
-        />
-      </div>
-      {embconfigs.length > 0 ? (
-        <div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2">
-            {embconfigs.map((emb) => (
-              <Card
-                key={emb.id}
-                className="flex flex-col border rounded-lg shadow-sm h-full pt-4 pb-2"
-              >
-                <CardHeader>
-                  <CardTitle className="text-sm font-medium">
-                    <div className="flex items-center gap-3 flex-wrap">
-                      {emb.is_default && (
-                        <Badge className="bg-red-100 text-red-800">{t('config.model.default')}</Badge>
-                      )}
-                      <Badge className="bg-yellow-100 text-yellow-800">
-                        {emb.model_name}
-                      </Badge>
-                      <Badge className="bg-blue-100 text-blue-800">
-                        {emb.type}
-                      </Badge>
-                      {emb.type === 'local' ? (
-                        <Badge
-                          className={
-                            emb.is_ready
-                              ? 'bg-green-100 text-green-800'
-                              : 'bg-gray-100 text-gray-800'
-                          }
-                        >
-                          {emb.is_ready ? (
-                            <span className="inline-flex items-center">
-                              {' '}
-                              {t('config.model.available')}{' '}
-                              <CheckCircle className="h-3 w-3 text-green-500" />{' '}
-                            </span>
-                          ) : (
-                            <span className="inline-flex items-center">
-                              {' '}
-                              {t('config.model.downloading')}{' '}
-                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            </span>
-                          )}
-                        </Badge>
-                      ) : (
-                        <Badge className="bg-green-100 text-green-800">
-                          <span className="inline-flex items-center">
-                            {' '}
-                            {t('config.model.available')}{' '}
-                            <CheckCircle className="h-3 w-3 text-green-500" />{' '}
-                          </span>
-                        </Badge>
-                      )}
-                    </div>
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="pt-0 pb-0">
-                  <p className="truncate">{emb.model_id}</p>
-                  <p className="truncate text-xs text-muted-foreground pt-2">
-                    {emb.endpoint}
-                  </p>
-                </CardContent>
-                <CardFooter className="mt-auto pt-0 flex justify-end pb-0">
-                  <Button
-                    variant="link"
-                    onClick={() => removeModel(emb.id, 'embeddings')}
-                    className="text-sm text-primary text-red-600 hover:text-primary/80 underline-offset-4 hover:underline"
-                  >
-                    <TrashIcon className="ml-1" size={16} />
-                  </Button>
+  const openCreate = () => {
+    setIsCreateOpen(true);
+    setEditEmbConfig(newembconfig);
+  };
 
-                  <Button
-                    variant="link"
-                    className="text-sm text-primary text-blue-600 hover:text-primary/80 underline-offset-4 hover:underline"
-                    onClick={() => {
-                      setEditEmbConfig(emb);
-                      setIsEditOpen(true);
-                    }}
+  return (
+    <section id="embedding" className="section-panel">
+      {/* Section header */}
+      <div className="section-header">
+        <div className="flex items-center gap-2">
+          <Layers className="w-4 h-4 text-primary" />
+          <h2 className="section-title">{t('config.model.tabEmbedding') || 'Embedding'}</h2>
+          <span className="text-xs text-muted-foreground">· {embconfigs.length}</span>
+        </div>
+        <Button size="sm" variant="outline" onClick={openCreate}>
+          <Plus className="w-4 h-4" />
+          Add
+        </Button>
+      </div>
+
+      <EmbeddingModelDialog
+        isAdd={isCreateOpen ? true : false}
+        isOpen={isEditOpen || isCreateOpen}
+        setIsOpen={(open: boolean) => {
+          if (!open) {
+            setEditEmbConfig(newembconfig);
+          }
+          setIsEditOpen(open);
+          setIsCreateOpen(open);
+        }}
+        embConfig={editEmbConfig || newembconfig}
+        onSaveSuccess={(emb: EmbConfig) => {
+          if (isCreateOpen) handleCreateSuccess(emb);
+          else handleSaveSuccess(emb);
+        }}
+      />
+
+      {embconfigs.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3">
+          {embconfigs.map((emb) => (
+            <div key={emb.id} className="model-card group">
+              {/* Top-right corner: type badge + default + more menu */}
+              <div className="absolute top-3 right-3 flex items-center gap-2">
+                {emb.is_default && (
+                  <Badge className="badge-danger text-[10.5px] py-0">
+                    {t('config.model.default')}
+                  </Badge>
+                )}
+                <span className="type-corner-badge type-embedding">EMB</span>
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger asChild>
+                    <button type="button" className="icon-action-btn" aria-label="More">
+                      <MoreHorizontal className="w-4 h-4" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="menu-compact">
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        setEditEmbConfig(emb);
+                        setIsEditOpen(true);
+                      }}
+                    >
+                      <Edit />
+                      {t('common.edit') || 'Edit'}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onSelect={() => removeModel(emb.id)}
+                    >
+                      <TrashIcon />
+                      {t('common.delete') || 'Delete'}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+
+              <div className="flex items-start gap-3 pr-28">
+                <div className="model-icon type-embedding shrink-0">{(emb.model_name || 'E').charAt(0)}</div>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-sm truncate" title={emb.model_id}>
+                    {emb.model_id}
+                  </div>
+                  <div className="text-xs text-muted-foreground truncate">{emb.model_name}</div>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-1.5 flex-wrap">
+                <Badge className="badge-tech text-[10.5px] py-0">{emb.type}</Badge>
+                {emb.type === 'local' ? (
+                  <Badge
+                    className={
+                      (emb.is_ready ? 'badge-success' : 'badge-neutral') +
+                      ' text-[10.5px] py-0'
+                    }
                   >
-                    <Edit className="ml-1" size={16} />
-                  </Button>
-                </CardFooter>
-              </Card>
-            ))}
-          </div>
-          <div className="flex justify-center items-center h-1/10 py-6">
-            <PaginationComponent
-              currentPage={page}
-              totalPages={totalPages}
-              onPageChange={handlePageChange}
-            />
-          </div>
+                    {emb.is_ready ? (
+                      <span className="inline-flex items-center gap-1">
+                        {t('config.model.available')}
+                        <CheckCircle className="h-3 w-3" />
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1">
+                        {t('config.model.downloading')}
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      </span>
+                    )}
+                  </Badge>
+                ) : (
+                  <Badge className="badge-success text-[10.5px] py-0">
+                    <span className="inline-flex items-center gap-1">
+                      {t('config.model.available')}
+                      <CheckCircle className="h-3 w-3" />
+                    </span>
+                  </Badge>
+                )}
+              </div>
+
+              {emb.endpoint && (
+                <div className="endpoint-text" title={emb.endpoint}>
+                  {emb.endpoint}
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       ) : (
-        <div className="flex justify-center items-center h-1/10 py-6">
-          <h3 className="text-lg font-medium text-gray-700 py-6">
-            {t('config.model.noModelsYet')}
-          </h3>
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <Layers className="w-10 h-10 text-muted-foreground/40 mb-2" />
+          <p className="text-sm text-muted-foreground">
+            暂无模型，点击右上角按钮添加
+          </p>
         </div>
       )}
-      <div className="block w-full">
-        {errorMsg !== '' && (
+
+      {errorMsg !== '' && (
+        <div className="block w-full mt-3">
           <Alert variant="destructive">
             <AlertCircleIcon />
             <AlertDescription>
               <p>{errorMsg}</p>
             </AlertDescription>
           </Alert>
-        )}
-      </div>
-    </div>
+        </div>
+      )}
+    </section>
   );
 }

--- a/frontend/app/config/model/llm/modelDialog.tsx
+++ b/frontend/app/config/model/llm/modelDialog.tsx
@@ -10,14 +10,12 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Alert, AlertTitle } from '@/components/ui/alert';
 import { AlertCircleIcon } from 'lucide-react';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
-// 定义组件 props
 interface LLMModelDialogProps {
   isAdd: boolean;
   isOpen: boolean;
@@ -26,7 +24,6 @@ interface LLMModelDialogProps {
   onSaveSuccess: (llm: LlmConfig) => void;
 }
 
-// 模型数据类型
 interface LlmConfig {
   id: string;
   model_id: string;
@@ -37,8 +34,8 @@ interface LlmConfig {
   max_context: number;
   enabled: boolean;
   vision_support: boolean;
-  enable_thinking: boolean; // 是否支持思考模式
-  temperature: number; // 温度参数，控制生成文本的随机性
+  enable_thinking: boolean;
+  temperature: number;
 }
 
 export const LLMModelDialog: FC<LLMModelDialogProps> = ({
@@ -50,9 +47,15 @@ export const LLMModelDialog: FC<LLMModelDialogProps> = ({
 }) => {
   const { t } = useI18n();
   const [llm, setLlm] = useState<LlmConfig>(llmConfig);
-  const [error, setError] = useState<string | null>(null);
   const [saveErrorMsg, setSaveErrorMsg] = useState('');
   const { tenantFetch } = useTenantFetch();
+
+  // Freeze isAdd while the dialog is closing (prevents title flicker
+  // between "Add" and "Edit" during close animation).
+  const [displayIsAdd, setDisplayIsAdd] = useState(isAdd);
+  useEffect(() => {
+    if (isOpen) setDisplayIsAdd(isAdd);
+  }, [isOpen, isAdd]);
 
   useEffect(() => {
     setLlm(llmConfig);
@@ -64,19 +67,13 @@ export const LLMModelDialog: FC<LLMModelDialogProps> = ({
 
   const handleSubmit = async () => {
     setSaveErrorMsg('');
-    if (
-      !llm.model ||
-      (isAdd && !llm.api_key) ||
-      !llm.base_url ||
-      !llm.model_id
-    ) {
+    if (!llm.model || (isAdd && !llm.api_key) || !llm.base_url || !llm.model_id) {
       setSaveErrorMsg(t('config.model.fillCompleteInfo'));
       return;
     }
     const submit_url = isAdd ? `/api/config/llms` : `/api/config/llms/${llm.id}`;
     const updateMethod = isAdd ? 'POST' : 'PUT';
     if (llm.api_key === '******') llm.api_key = '';
-    console.log('updateMethod', isAdd, updateMethod, submit_url, llm);
     try {
       const res = await tenantFetch(submit_url, {
         method: updateMethod,
@@ -89,186 +86,176 @@ export const LLMModelDialog: FC<LLMModelDialogProps> = ({
         return;
       }
       const jsondata = await res.json();
-      onSaveSuccess(jsondata.data as LlmConfig); // 触发回调
+      onSaveSuccess(jsondata.data as LlmConfig);
       setIsOpen(false);
     } catch (err: any) {
       setSaveErrorMsg(t('config.model.requestFailed', { method: updateMethod }));
     }
   };
 
-  // 对话框关闭时重置表单
   const handleDialogClose = (open: boolean) => {
     setIsOpen(open);
-    if (!open) {
-      setError(null);
-      setSaveErrorMsg('');
-    }
+    if (!open) setSaveErrorMsg('');
   };
 
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogClose}>
-      <DialogContent className="sm:max-w-[700px]">
-        {error && <div className="text-red-500 mb-4">{error}</div>}
+      <DialogContent className="sm:max-w-[560px]">
         <DialogHeader>
-          <DialogTitle>{isAdd ? t('config.model.addModel') : t('config.model.editModel')}</DialogTitle>
-          <DialogDescription>{t('config.model.fillModelConfig')}</DialogDescription>
+          <DialogTitle className="flex items-center gap-2">
+            <span className="type-corner-badge type-llm">LLM</span>
+            {displayIsAdd ? '添加 LLM 模型' : '编辑 LLM 模型'}
+          </DialogTitle>
+          <DialogDescription>
+            填写大语言模型（LLM）的配置信息后保存
+          </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-4 py-2">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="model_id" className="text-right">
-              {t('config.model.modelId')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="model_id"
-              placeholder={t('config.model.modelIdPlaceholder')}
-              value={llm?.model_id ?? ''}
-              onChange={(e) =>
-                setLlm((prev) => ({ ...prev, model_id: e.target.value }))
-              }
-              className="col-span-3"
-            />
-          </div>
-        </div>
-        <div>
-          <div className="grid grid-cols-4 items-center gap-4 py-2">
-            <Label htmlFor="base_url" className="text-right">
-              {t('config.model.endpointUrl')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <div className="col-span-3">
-              <input
-                id="base_url"
-                list="base_url_options"
-                placeholder={t('config.model.baseUrlPlaceholder')}
-                value={llm?.base_url ?? ''}
-                onChange={(e) =>
-                  setLlm((prev) => ({ ...prev, base_url: e.target.value }))
-                }
-                className="w-full border border-gray-300 rounded-md p-2 text-sm"
-              />
-              <datalist id="base_url_options">
-                <option value="https://api.openai.com/v1">OpenAI</option>
-                <option value="https://dashscope.aliyuncs.com/compatible-mode/v1">
-                  {t('config.model.qwenModel')}
-                </option>
-                {/* 添加更多预设选项 */}
-              </datalist>
-            </div>
-          </div>
-          <div className="grid grid-cols-4 items-center gap-4 py-2">
-            <Label htmlFor="api_key" className="text-right">
-              {t('config.model.apiKey')}
-              <span className="text-destructive">*</span>
-            </Label>
-            {isAdd ? (
-              <Input
-                id="api_key"
-                type="password"
-                placeholder={t('config.model.apiKeyPlaceholder')}
-                value={llm?.api_key ?? ''}
-                onChange={(e) =>
-                  setLlm((prev) => ({ ...prev, api_key: e.target.value }))
-                }
-                className="col-span-3"
-              />
-            ) : (
-              <Input
-                id="api_key"
-                type="password"
-                placeholder={t('config.model.apiKeyPlaceholder')}
-                value={llm?.api_key || '******'}
-                onChange={(e) =>
-                  setLlm((prev) => ({ ...prev, api_key: e.target.value }))
-                }
-                className="col-span-3"
-              />
-            )}
-          </div>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="model" className="text-right">
-              {t('config.model.modelName')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="model"
-              placeholder={t('config.model.modelNamePlaceholder')}
-              value={llm?.model ?? ''}
-              onChange={(e) =>
-                setLlm((prev) => ({ ...prev, model: e.target.value }))
-              }
-              className="col-span-3"
-            />
-          </div>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="vision_support" className="text-right">
-              {t('config.model.visionModel')}
-            </Label>
-            <Switch
-              id="vision_support"
-              checked={llm?.vision_support ?? false}
-              onCheckedChange={(checked) =>
-                setLlm((prev) => ({ ...prev, vision_support: checked }))
-              }
-            />
-          </div>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="enable_thinking" className="text-right">
-              {t('config.model.thinkingModel')}
-            </Label>
-            <Switch
-              id="enable_thinking"
-              checked={llm?.enable_thinking ?? false}
-              onCheckedChange={(checked) =>
-                setLlm((prev) => ({ ...prev, enable_thinking: checked }))
-              }
-            />
-          </div>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="temperature" className="text-right">
-              {t('config.model.temperature')}
-            </Label>
-            <div className="col-span-3">
-              <Input
-                id="temperature"
-                type="number"
-                step="0.1"
-                min="0"
-                placeholder="0.1"
-                value={llm?.temperature ?? 0.1}
-                onChange={(e) => {
-                  const val = parseFloat(e.target.value);
-                  setLlm((prev) => ({
-                    ...prev,
-                    temperature: isNaN(val) || val < 0 ? 0.1 : val,
-                  }));
-                }}
-                className="w-[80px]"
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                {t('config.model.temperatureHint')}
-              </p>
-            </div>
-          </div>
-        </div>
+        <div className="space-y-4 py-2">
+          {/* Basic section */}
+          <div>
+            <div className="dialog-section-title">Basic</div>
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="model_id" className="form-label">
+                  {t('config.model.modelId')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="model_id"
+                  placeholder={t('config.model.modelIdPlaceholder')}
+                  value={llm?.model_id ?? ''}
+                  onChange={(e) => setLlm((prev) => ({ ...prev, model_id: e.target.value }))}
+                />
+              </div>
 
-        <DialogFooter className="flex flex-col gap-4">
+              <div>
+                <label htmlFor="model" className="form-label">
+                  {t('config.model.modelName')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="model"
+                  placeholder={t('config.model.modelNamePlaceholder')}
+                  value={llm?.model ?? ''}
+                  onChange={(e) => setLlm((prev) => ({ ...prev, model: e.target.value }))}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Endpoint section */}
+          <div>
+            <div className="dialog-section-title">Endpoint</div>
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="base_url" className="form-label">
+                  {t('config.model.endpointUrl')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="base_url"
+                  list="base_url_options"
+                  placeholder={t('config.model.baseUrlPlaceholder')}
+                  value={llm?.base_url ?? ''}
+                  onChange={(e) => setLlm((prev) => ({ ...prev, base_url: e.target.value }))}
+                />
+                <datalist id="base_url_options">
+                  <option value="https://api.openai.com/v1">OpenAI</option>
+                  <option value="https://dashscope.aliyuncs.com/compatible-mode/v1">
+                    {t('config.model.qwenModel')}
+                  </option>
+                </datalist>
+              </div>
+
+              <div>
+                <label htmlFor="api_key" className="form-label">
+                  {t('config.model.apiKey')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="api_key"
+                  type="password"
+                  placeholder={t('config.model.apiKeyPlaceholder')}
+                  value={isAdd ? (llm?.api_key ?? '') : (llm?.api_key || '******')}
+                  onChange={(e) => setLlm((prev) => ({ ...prev, api_key: e.target.value }))}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Advanced section */}
+          <div>
+            <div className="dialog-section-title">Advanced</div>
+            <div className="space-y-2">
+              <div className="form-row-inline">
+                <div className="form-row-inline-label">
+                  <span className="title">{t('config.model.visionModel')}</span>
+                  <span className="hint">支持图像输入</span>
+                </div>
+                <Switch
+                  id="vision_support"
+                  checked={llm?.vision_support ?? false}
+                  onCheckedChange={(checked) =>
+                    setLlm((prev) => ({ ...prev, vision_support: checked }))
+                  }
+                />
+              </div>
+
+              <div className="form-row-inline">
+                <div className="form-row-inline-label">
+                  <span className="title">{t('config.model.thinkingModel')}</span>
+                  <span className="hint">开启链式思考 (Chain of Thought)</span>
+                </div>
+                <Switch
+                  id="enable_thinking"
+                  checked={llm?.enable_thinking ?? false}
+                  onCheckedChange={(checked) =>
+                    setLlm((prev) => ({ ...prev, enable_thinking: checked }))
+                  }
+                />
+              </div>
+
+              <div className="form-row-inline">
+                <div className="form-row-inline-label">
+                  <span className="title">{t('config.model.temperature')}</span>
+                  <span className="hint">{t('config.model.temperatureHint')}</span>
+                </div>
+                <Input
+                  id="temperature"
+                  type="number"
+                  step="0.1"
+                  min="0"
+                  max="2"
+                  value={llm?.temperature ?? 0.1}
+                  onChange={(e) => {
+                    const val = parseFloat(e.target.value);
+                    setLlm((prev) => ({
+                      ...prev,
+                      temperature: isNaN(val) || val < 0 ? 0.1 : val,
+                    }));
+                  }}
+                  className="w-20 h-8 text-right"
+                />
+              </div>
+            </div>
+          </div>
+
           {saveErrorMsg !== '' && (
             <Alert className="bg-destructive/10 dark:bg-destructive/20 border-none">
               <AlertCircleIcon className="h-4 w-4 !text-destructive" />
               <AlertTitle>{saveErrorMsg}</AlertTitle>
             </Alert>
           )}
-          <Button onClick={handleSubmit}>{isAdd ? t('config.model.create') : t('common.save')}</Button>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setIsOpen(false)}>
+            {t('common.cancel') || 'Cancel'}
+          </Button>
+          <Button onClick={handleSubmit}>
+            {displayIsAdd ? '创建 LLM 模型' : t('common.save')}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/app/config/model/llm/page.tsx
+++ b/frontend/app/config/model/llm/page.tsx
@@ -1,20 +1,17 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { TrashIcon, Edit, AlertCircleIcon } from 'lucide-react';
+import { TrashIcon, Edit, AlertCircleIcon, Plus, Bot, MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Switch } from '@/components/ui/switch';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardFooter,
-} from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { LLMModelDialog } from '@/app/config/model/llm/modelDialog';
-import { PaginationComponent } from '@/components/customized/pagination/pagination-component';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
@@ -28,8 +25,8 @@ export interface LlmConfig {
   max_context: number;
   enabled: boolean;
   vision_support: boolean;
-  enable_thinking: boolean; // 是否支持思考模式
-  temperature: number; // 温度参数
+  enable_thinking: boolean;
+  temperature: number;
 }
 
 const newllmconfig: LlmConfig = {
@@ -42,47 +39,35 @@ const newllmconfig: LlmConfig = {
   vision_support: false,
   max_context: 0,
   enabled: true,
-  enable_thinking: false, // 默认支持思考模式
-  temperature: 0.1, // 默认温度 0.1
+  enable_thinking: false,
+  temperature: 0.1,
 };
 export default function LlmConfigPage() {
   const { t } = useI18n();
   const [editLlmConfig, setEditLlmConfig] = useState<LlmConfig>(newllmconfig);
-  const [llmconfigs, setLlmConfigs] = useState<LlmConfig[]>([]); // 存储 LLM 配置
-  const [modelloading, setModelLoading] = useState(true); // 加载状态
-  const [modelerror, setModelError] = useState(''); // 错误信息
-  const [errorMsg, setErrorMsg] = useState(''); // 删除或更新时的错误信息
-
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const modelSizePerPage = 8;
+  const [llmconfigs, setLlmConfigs] = useState<LlmConfig[]>([]);
+  const [errorMsg, setErrorMsg] = useState('');
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const { tenantFetch } = useTenantFetch();
+
   useEffect(() => {
     const fetchModelConfigs = async () => {
       try {
-        const res = await tenantFetch(
-          `/api/config/llms?page=${page}&size=${modelSizePerPage}`,
-        );
+        const res = await tenantFetch(`/api/config/llms?page=1&size=100`);
         if (!res.ok) throw new Error(t('config.model.fetchLlmListFailed'));
         const json_data = await res.json();
-        const data = json_data.data.items;
-        setLlmConfigs(data); // 合并
-        setTotalPages(json_data.data.pages);
+        setLlmConfigs(json_data.data.items || []);
       } catch (err: any) {
-        setModelError(err || t('config.model.loadFailed'));
-      } finally {
-        setModelLoading(false);
+        // swallow — error reported via errorMsg on mutations
       }
     };
     fetchModelConfigs();
-  }, [page, llmconfigs.length]);
+  }, [llmconfigs.length]);
 
   const handleCreateSuccess = (llmConfig: LlmConfig) => {
-    setLlmConfigs((prev) => [...prev, llmConfig]); // 追加新 LLM 配置
-    console.log('创建LLM成功', llmConfig);
+    setLlmConfigs((prev) => [...prev, llmConfig]);
     setEditLlmConfig(newllmconfig);
   };
 
@@ -90,200 +75,149 @@ export default function LlmConfigPage() {
     setLlmConfigs((prev) =>
       prev.map((config) => (config.id === llmConfig.id ? llmConfig : config)),
     );
-    console.log('编辑LLM成功', llmConfig);
     setEditLlmConfig(newllmconfig);
   };
 
-  const handlePageChange = (newPage: number) => {
-    if (newPage < 1 || newPage > totalPages) return;
-    setPage(newPage);
-  };
-
-  const handleActivateToggle = async (llm: LlmConfig) => {
-    setErrorMsg('');
-    llm.enabled = !llm.enabled;
-    const url = `/api/config/llms/${llm.id}`;
-
-    const res = await tenantFetch(url, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(llm), // 包装为数组
-    });
-
-    if (!res.ok) {
-      setErrorMsg(t('config.model.updateStatusFailed'));
-      return;
-    }
-    setLlmConfigs((prev) =>
-      prev.map((c) => (c.id === llm.id ? { ...c, enabled: llm.enabled } : c)),
-    );
-  };
-
-  const removeModel = async (id: string, model_type: string) => {
+  const removeModel = async (id: string) => {
     setErrorMsg('');
     try {
-      console.log('removeModel: id: ', id, 'model_type: ', model_type);
-      const res = await tenantFetch(`/api/config/${model_type}/${id}`, {
+      const res = await tenantFetch(`/api/config/llms/${id}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
 
       if (!res.ok) {
         setErrorMsg(t('config.model.deleteModelFailed', { modelType: 'LLM' }));
         return;
       }
-
-      // 删除成功后更新本地状态
-      if (model_type === 'llms') {
-        setLlmConfigs((prev) => prev.filter((config) => config.id !== id));
-      }
+      setLlmConfigs((prev) => prev.filter((config) => config.id !== id));
     } catch (err: any) {
       setErrorMsg(t('config.model.deleteFailed'));
     }
   };
 
-  return (
-    <div id="llm">
-      <div className="grid grid-cols-1 pb-8">
-        <Button
-          onClick={() => {
-            setIsCreateOpen(true);
-            setEditLlmConfig(newllmconfig);
-          }}
-        >
-          {t('config.model.addLlmModel')}
-        </Button>
-        <LLMModelDialog
-          isAdd={isCreateOpen ? true : false}
-          isOpen={isEditOpen || isCreateOpen}
-          setIsOpen={(open) => {
-            if (!open) {
-              setEditLlmConfig(newllmconfig); // 关闭时清空编辑数据
-            }
-            setIsEditOpen(open);
-            setIsCreateOpen(open);
-          }}
-          llmConfig={editLlmConfig || newllmconfig}
-          onSaveSuccess={(llm) => {
-            if (isCreateOpen) {
-              handleCreateSuccess(llm);
-            } else {
-              handleSaveSuccess(llm);
-            }
-          }}
-        />
-      </div>
-      {llmconfigs.length > 0 ? (
-        <div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2">
-            {llmconfigs.map((llm) => (
-              <Card
-                key={llm.id}
-                className="flex flex-col border rounded-lg shadow-sm h-full pt-4 pb-0 gap-2"
-              >
-                <CardHeader>
-                  <CardTitle className="text-sm font-medium">
-                    <div className="flex items-center gap-3 flex-wrap">
-                      <Badge className="bg-blue-100 text-blue-800">
-                        {llm.source}
-                      </Badge>
-                      <Badge className="bg-red-100 text-red-800">
-                        {llm.model}
-                      </Badge>
-                      <Badge
-                        className='bg-yellow-100 text-yellow-800'
-                      >
-                        {t('config.model.languageModel')}
-                      </Badge>
-                      {
-                        llm.vision_support && (
-                          <Badge className="bg-yellow-100 text-yellow-800">
-                            {t('config.model.visionModel')}
-                          </Badge>
-                        )
-                      }
-                      {
-                        llm.enable_thinking && (
-                          <Badge className="bg-yellow-100 text-yellow-800">
-                            {t('config.model.thinkingModel')}
-                          </Badge>
-                        )
-                      }
-                      {
-                        llm.enabled ? (
-                          <Badge className="bg-green-100 text-green-800">
-                            {t('config.model.activated')}
-                          </Badge>
-                        ) : (
-                          <Badge className="bg-gray-100 text-gray-800">
-                            {t('config.model.deactivated')}
-                          </Badge>
-                        )
-                      }
-                      <Switch
-                        checked={llm.enabled}
-                        className="ml-auto rounded-full transition-color"
-                        onCheckedChange={() => handleActivateToggle(llm)}
-                      />
-                    </div>
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="pt-0 pb-0">
-                  <p className="truncate">{llm.model_id}</p>
-                  <p className="truncate text-muted-foreground py-2 text-xs line-clamp-1">
-                    {llm.base_url}
-                  </p>
-                </CardContent>
-                <CardFooter className="mt-auto pt-0 pb-2 gap-4 flex justify-end">
-                  <Button
-                    variant="link"
-                    onClick={() => removeModel(llm.id, 'llms')}
-                    className="text-sm text-primary text-red-600 hover:text-primary/80 underline-offset-4 hover:underline"
-                  >
-                    <TrashIcon className="ml-1" size={16} />
-                  </Button>
+  const openCreate = () => {
+    setIsCreateOpen(true);
+    setEditLlmConfig(newllmconfig);
+  };
 
-                  <Button
-                    variant="link"
-                    className="text-sm text-primary text-blue-600 hover:text-primary/80 underline-offset-4 hover:underline"
-                    onClick={() => {
-                      setEditLlmConfig(llm);
-                      setIsEditOpen(true);
-                    }}
-                  >
-                    <Edit className="ml-1" size={16} />
-                  </Button>
-                </CardFooter>
-              </Card>
-            ))}
-          </div>
-          <div className="flex justify-center items-center h-1/10 py-6">
-            <PaginationComponent
-              currentPage={page}
-              totalPages={totalPages}
-              onPageChange={handlePageChange}
-            />
-          </div>
+  return (
+    <section id="llm" className="section-panel">
+      {/* Section header */}
+      <div className="section-header">
+        <div className="flex items-center gap-2">
+          <Bot className="w-4 h-4 text-primary" />
+          <h2 className="section-title">{t('config.model.tabLlm') || 'LLM'}</h2>
+          <span className="text-xs text-muted-foreground">· {llmconfigs.length}</span>
+        </div>
+        <Button size="sm" variant="outline" onClick={openCreate}>
+          <Plus className="w-4 h-4" />
+          Add
+        </Button>
+      </div>
+
+      <LLMModelDialog
+        isAdd={isCreateOpen ? true : false}
+        isOpen={isEditOpen || isCreateOpen}
+        setIsOpen={(open) => {
+          if (!open) {
+            setEditLlmConfig(newllmconfig);
+          }
+          setIsEditOpen(open);
+          setIsCreateOpen(open);
+        }}
+        llmConfig={editLlmConfig || newllmconfig}
+        onSaveSuccess={(llm) => {
+          if (isCreateOpen) handleCreateSuccess(llm);
+          else handleSaveSuccess(llm);
+        }}
+      />
+
+      {llmconfigs.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3">
+          {llmconfigs.map((llm) => (
+            <div key={llm.id} className="model-card group">
+              {/* Top-right corner: type badge + more menu */}
+              <div className="absolute top-3 right-3 flex items-center gap-2">
+                <span className="type-corner-badge type-llm">LLM</span>
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger asChild>
+                    <button type="button" className="icon-action-btn" aria-label="More">
+                      <MoreHorizontal className="w-4 h-4" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="menu-compact">
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        setEditLlmConfig(llm);
+                        setIsEditOpen(true);
+                      }}
+                    >
+                      <Edit />
+                      {t('common.edit') || 'Edit'}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onSelect={() => removeModel(llm.id)}
+                    >
+                      <TrashIcon />
+                      {t('common.delete') || 'Delete'}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+
+              <div className="flex items-start gap-3 pr-20">
+                <div className="model-icon type-llm shrink-0">{(llm.model_id || 'M').charAt(0)}</div>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-sm truncate" title={llm.model_id}>
+                    {llm.model_id}
+                  </div>
+                  <div className="text-xs text-muted-foreground truncate">{llm.model}</div>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-1.5 flex-wrap">
+                <Badge className="badge-tech text-[10.5px] py-0">{llm.source}</Badge>
+                {llm.vision_support && (
+                  <Badge className="badge-warning text-[10.5px] py-0">
+                    {t('config.model.visionModel')}
+                  </Badge>
+                )}
+                {llm.enable_thinking && (
+                  <Badge className="badge-warning text-[10.5px] py-0">
+                    {t('config.model.thinkingModel')}
+                  </Badge>
+                )}
+              </div>
+
+              {llm.base_url && (
+                <div className="endpoint-text" title={llm.base_url}>
+                  {llm.base_url}
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       ) : (
-        <div className="flex justify-center items-center h-1/10 py-6">
-          <h3 className="text-lg font-medium text-gray-700 py-6">
-            {t('config.model.noModelsYet')}
-          </h3>
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <Bot className="w-10 h-10 text-muted-foreground/40 mb-2" />
+          <p className="text-sm text-muted-foreground">
+            暂无模型，点击右上角按钮添加
+          </p>
         </div>
       )}
-      <div className="block w-full">
-        {errorMsg !== '' && (
+
+      {errorMsg !== '' && (
+        <div className="block w-full mt-3">
           <Alert variant="destructive">
             <AlertCircleIcon />
             <AlertDescription>
               <p>{errorMsg}</p>
             </AlertDescription>
           </Alert>
-        )}
-      </div>
-    </div>
+        </div>
+      )}
+    </section>
   );
 }

--- a/frontend/app/config/model/page.tsx
+++ b/frontend/app/config/model/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import LlmConfigPage from '@/app/config/model/llm/page';
 import EmbConfigPage from '@/app/config/model/embedding/page';
 import RerankerConfigPage from '@/app/config/model/reranker/page';
@@ -12,35 +11,16 @@ export default function ModelConfigPage() {
 
   return (
     <div id="model">
-      <div className="flex flex-col h-screen p-2">
-        <div className="flex items-center h-1/10">
-          <h1 className="text-xl font-medium">{t('config.model.title')}</h1>
+      <div className="flex flex-col h-screen px-6 py-4">
+        <div className="flex items-center pb-4">
+          <h1 className="page-title">{t('config.model.title')}</h1>
         </div>
 
         <div className="flex-1 overflow-y-auto">
-          <div className="">
-            <Tabs defaultValue="llms">
-              <TabsList className="py-4 bg-muted rounded-lg flex-none">
-                <TabsTrigger value="llms" className="p-4">
-                  {t('config.model.tabLlm')}
-                </TabsTrigger>
-                <TabsTrigger value="embeddings" className="p-4">
-                  {t('config.model.tabEmbedding')}
-                </TabsTrigger>
-                <TabsTrigger value="rerankers" className="p-4">
-                  {t('config.model.tabReranker')}
-                </TabsTrigger>
-              </TabsList>
-              <TabsContent value="llms" className="py-4">
-                <LlmConfigPage />
-              </TabsContent>
-              <TabsContent value="embeddings" className="py-4">
-                <EmbConfigPage />
-              </TabsContent>
-              <TabsContent value="rerankers" className="py-4">
-                <RerankerConfigPage />
-              </TabsContent>
-            </Tabs>
+          <div className="space-y-4 pb-6">
+            <LlmConfigPage />
+            <EmbConfigPage />
+            <RerankerConfigPage />
           </div>
         </div>
       </div>

--- a/frontend/app/config/model/reranker/modelDialog.tsx
+++ b/frontend/app/config/model/reranker/modelDialog.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Alert, AlertTitle } from '@/components/ui/alert';
 import {
   Select,
@@ -23,7 +22,6 @@ import { AlertCircleIcon } from 'lucide-react';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
-// Component props
 interface RerankerModelDialogProps {
   isAdd: boolean;
   isOpen: boolean;
@@ -49,11 +47,16 @@ export const RerankerModelDialog: FC<RerankerModelDialogProps> = ({
   onSaveSuccess,
 }) => {
   const [reranker, setReranker] = useState<RerankerConfig>(rerankerConfig);
-  const [error, setError] = useState<string | null>(null);
   const [saveErrorMsg, setSaveErrorMsg] = useState('');
   const { tenantFetch } = useTenantFetch();
   const { t } = useI18n();
-  
+
+  // Freeze isAdd while the dialog is closing (prevents title flicker).
+  const [displayIsAdd, setDisplayIsAdd] = useState(isAdd);
+  useEffect(() => {
+    if (isOpen) setDisplayIsAdd(isAdd);
+  }, [isOpen, isAdd]);
+
   useEffect(() => {
     setReranker(rerankerConfig);
   }, [isAdd, rerankerConfig]);
@@ -64,7 +67,6 @@ export const RerankerModelDialog: FC<RerankerModelDialogProps> = ({
 
   const handleSubmit = async () => {
     setSaveErrorMsg('');
-    console.log('reranker', reranker);
     if (
       !reranker.model_id ||
       (isAdd && !reranker.api_key) ||
@@ -79,18 +81,18 @@ export const RerankerModelDialog: FC<RerankerModelDialogProps> = ({
       : `/api/config/rerankers/${reranker.id}`;
     const updateMethod = isAdd ? 'POST' : 'PUT';
     if (reranker.api_key === '******') reranker.api_key = '';
-    
-    // Convert frontend type values to backend format
+
     const typeMapping: Record<string, string> = {
-      'OpenAICompatible': 'openai_like',
-      'DashScope': 'dashscope',
+      OpenAICompatible: 'openai_like',
+      DashScope: 'dashscope',
     };
     const submitData = {
       ...reranker,
-      type: reranker.type ? (typeMapping[reranker.type] || reranker.type) : 'openai_like',
+      type: reranker.type
+        ? typeMapping[reranker.type] || reranker.type
+        : 'openai_like',
     };
-    
-    console.log('updateMethod', isAdd, updateMethod, submit_url, submitData);
+
     try {
       const res = await tenantFetch(submit_url, {
         method: updateMethod,
@@ -103,14 +105,15 @@ export const RerankerModelDialog: FC<RerankerModelDialogProps> = ({
         return;
       }
       const jsondata = await res.json();
-      // Convert backend type values to frontend format
       const reverseTypeMapping: Record<string, string> = {
-        'openai_like': 'OpenAICompatible',
-        'dashscope': 'DashScope',
+        openai_like: 'OpenAICompatible',
+        dashscope: 'DashScope',
       };
       const responseData = {
         ...jsondata.data,
-        type: jsondata.data.type ? (reverseTypeMapping[jsondata.data.type] || jsondata.data.type) : 'OpenAICompatible',
+        type: jsondata.data.type
+          ? reverseTypeMapping[jsondata.data.type] || jsondata.data.type
+          : 'OpenAICompatible',
       };
       onSaveSuccess(responseData as RerankerConfig);
       setIsOpen(false);
@@ -119,139 +122,131 @@ export const RerankerModelDialog: FC<RerankerModelDialogProps> = ({
     }
   };
 
-  // Reset form when dialog closes
   const handleDialogClose = (open: boolean) => {
     setIsOpen(open);
-    if (!open) {
-      setError(null);
-      setSaveErrorMsg('');
-    }
+    if (!open) setSaveErrorMsg('');
   };
 
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogClose}>
-      <DialogContent className="sm:max-w-[700px]">
-        {error && <div className="text-red-500 mb-4">{error}</div>}
+      <DialogContent className="sm:max-w-[560px]">
         <DialogHeader>
-          <DialogTitle>{isAdd ? t('config.model.addModel') : t('config.model.editModel')}</DialogTitle>
-          <DialogDescription>{t('config.model.fillModelConfig')}</DialogDescription>
+          <DialogTitle className="flex items-center gap-2">
+            <span className="type-corner-badge type-reranker">RNK</span>
+            {displayIsAdd ? '添加 Reranker 模型' : '编辑 Reranker 模型'}
+          </DialogTitle>
+          <DialogDescription>
+            填写 Reranker（重排序）模型的配置信息后保存
+          </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-4 py-2">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="type" className="text-right">
-              {t('config.model.modelType')}
-            </Label>
-            <div className="col-span-3">
-              <Select
-                value={reranker?.type || 'OpenAICompatible'}
-                onValueChange={(value) =>
-                  setReranker((prev) => ({ ...prev, type: value }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder={t('config.model.selectModelType')} />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="OpenAICompatible">{t('config.model.openaiLike')}</SelectItem>
-                  <SelectItem value="DashScope">{t('config.model.qwenModel')}</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="model_id" className="text-right">
-              {t('config.model.modelId')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="model_id"
-              placeholder={t('config.model.modelIdPlaceholder')}
-              value={reranker?.model_id ?? ''}
-              onChange={(e) =>
-                setReranker((prev) => ({ ...prev, model_id: e.target.value }))
-              }
-              className="col-span-3"
-            />
-          </div>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="model_name" className="text-right">
-              {t('config.model.modelName')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="model_name"
-              placeholder={t('config.model.modelNamePlaceholder')}
-              value={reranker?.model_name ?? ''}
-              onChange={(e) =>
-                setReranker((prev) => ({ ...prev, model_name: e.target.value }))
-              }
-              className="col-span-3"
-            />
-          </div>
-        </div>
-        <div>
-          <div className="grid grid-cols-4 items-center gap-4 py-2">
-            <Label htmlFor="base_url" className="text-right">
-              {t('config.model.baseUrl')}
-              <span className="text-destructive">*</span>
-            </Label>
-            <div className="col-span-3">
-              <input
-                id="base_url"
-                list="base_url_options"
-                placeholder={t('config.model.baseUrlPlaceholder')}
-                value={reranker?.base_url ?? ''}
-                onChange={(e) =>
-                  setReranker((prev) => ({ ...prev, base_url: e.target.value }))
-                }
-                className="w-full border border-gray-300 rounded-md p-2 text-sm"
-              />
-            </div>
-          </div>
-          <div className="grid grid-cols-4 items-center gap-4 py-2">
-            <Label htmlFor="api_key" className="text-right">
-              {t('config.model.apiKey')}
-              <span className="text-destructive">*</span>
-            </Label>
-            {isAdd ? (
-              <Input
-                id="api_key"
-                type="password"
-                placeholder={t('config.model.apiKeyPlaceholder')}
-                value={reranker?.api_key ?? ''}
-                onChange={(e) =>
-                  setReranker((prev) => ({ ...prev, api_key: e.target.value }))
-                }
-                className="col-span-3"
-              />
-            ) : (
-              <Input
-                id="api_key"
-                type="password"
-                placeholder={t('config.model.apiKeyPlaceholder')}
-                value={reranker?.api_key || '******'}
-                onChange={(e) =>
-                  setReranker((prev) => ({ ...prev, api_key: e.target.value }))
-                }
-                className="col-span-3"
-              />
-            )}
-          </div>
-        </div>
+        <div className="space-y-4 py-2">
+          {/* Basic section */}
+          <div>
+            <div className="dialog-section-title">Basic</div>
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="model_id" className="form-label">
+                  {t('config.model.modelId')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="model_id"
+                  placeholder={t('config.model.modelIdPlaceholder')}
+                  value={reranker?.model_id ?? ''}
+                  onChange={(e) =>
+                    setReranker((prev) => ({ ...prev, model_id: e.target.value }))
+                  }
+                />
+              </div>
 
-        <DialogFooter className="flex flex-col gap-4">
+              <div>
+                <label htmlFor="model_name" className="form-label">
+                  {t('config.model.modelName')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="model_name"
+                  placeholder={t('config.model.modelNamePlaceholder')}
+                  value={reranker?.model_name ?? ''}
+                  onChange={(e) =>
+                    setReranker((prev) => ({ ...prev, model_name: e.target.value }))
+                  }
+                />
+              </div>
+
+              <div>
+                <label htmlFor="type" className="form-label">
+                  {t('config.model.modelType') || 'Type'}
+                </label>
+                <Select
+                  value={reranker?.type || 'OpenAICompatible'}
+                  onValueChange={(v) => setReranker((prev) => ({ ...prev, type: v }))}
+                >
+                  <SelectTrigger id="type" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="OpenAICompatible">OpenAI Compatible</SelectItem>
+                    <SelectItem value="DashScope">DashScope</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+
+          {/* Endpoint section */}
+          <div>
+            <div className="dialog-section-title">Endpoint</div>
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="base_url" className="form-label">
+                  {t('config.model.endpointUrl')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="base_url"
+                  placeholder={t('config.model.baseUrlPlaceholder')}
+                  value={reranker?.base_url ?? ''}
+                  onChange={(e) =>
+                    setReranker((prev) => ({ ...prev, base_url: e.target.value }))
+                  }
+                />
+              </div>
+
+              <div>
+                <label htmlFor="api_key" className="form-label">
+                  {t('config.model.apiKey')}
+                  <span className="required">*</span>
+                </label>
+                <Input
+                  id="api_key"
+                  type="password"
+                  placeholder={t('config.model.apiKeyPlaceholder')}
+                  value={isAdd ? (reranker?.api_key ?? '') : (reranker?.api_key || '******')}
+                  onChange={(e) =>
+                    setReranker((prev) => ({ ...prev, api_key: e.target.value }))
+                  }
+                />
+              </div>
+            </div>
+          </div>
+
           {saveErrorMsg !== '' && (
             <Alert className="bg-destructive/10 dark:bg-destructive/20 border-none">
               <AlertCircleIcon className="h-4 w-4 !text-destructive" />
               <AlertTitle>{saveErrorMsg}</AlertTitle>
             </Alert>
           )}
-          <Button onClick={handleSubmit}>{isAdd ? t('config.model.create') : t('common.save')}</Button>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setIsOpen(false)}>
+            {t('common.cancel') || 'Cancel'}
+          </Button>
+          <Button onClick={handleSubmit}>
+            {displayIsAdd ? '创建 Reranker 模型' : t('common.save')}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend/app/config/model/reranker/page.tsx
+++ b/frontend/app/config/model/reranker/page.tsx
@@ -1,19 +1,17 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { TrashIcon, Edit, AlertCircleIcon } from 'lucide-react';
+import { TrashIcon, Edit, AlertCircleIcon, Plus, Sparkles, MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardFooter,
-} from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { RerankerModelDialog } from '@/app/config/model/reranker/modelDialog';
-import { PaginationComponent } from '@/components/customized/pagination/pagination-component';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
@@ -39,13 +37,7 @@ export default function RerankerConfigPage() {
   const [editRerankerConfig, setEditRerankerConfig] =
     useState<RerankerConfig>(newrerankerconfig);
   const [rerankerconfigs, setRerankerConfigs] = useState<RerankerConfig[]>([]);
-  const [modelloading, setModelLoading] = useState(true);
-  const [modelerror, setModelError] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
-
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const modelSizePerPage = 8;
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
@@ -54,177 +46,169 @@ export default function RerankerConfigPage() {
   useEffect(() => {
     const fetchModelConfigs = async () => {
       try {
-        const res = await tenantFetch(
-          `/api/config/rerankers?page=${page}&size=${modelSizePerPage}`,
-        );
+        const res = await tenantFetch(`/api/config/rerankers?page=1&size=100`);
         if (!res.ok) throw new Error(t('config.model.fetchRerankerListFailed'));
         const json_data = await res.json();
-        // Convert backend type values to frontend format
         const reverseTypeMapping: Record<string, string> = {
           'openai_like': 'OpenAICompatible',
           'dashscope': 'DashScope',
         };
-        const data = json_data.data.items.map((item: RerankerConfig) => ({
+        const data = (json_data.data.items || []).map((item: RerankerConfig) => ({
           ...item,
           type: item.type ? (reverseTypeMapping[item.type] || item.type) : 'OpenAICompatible',
         }));
         setRerankerConfigs(data);
-        setTotalPages(json_data.data.pages);
       } catch (err: any) {
-        setModelError(err || t('config.model.loadFailed'));
-      } finally {
-        setModelLoading(false);
+        // swallow
       }
     };
     fetchModelConfigs();
-  }, [page, rerankerconfigs.length]);
+  }, [rerankerconfigs.length]);
 
-  const handleCreateSuccess = (llmConfig: RerankerConfig) => {
-    setRerankerConfigs((prev) => [...prev, llmConfig]);
-    console.log(t('config.model.createRerankerSuccess'), llmConfig);
+  const handleCreateSuccess = (config: RerankerConfig) => {
+    setRerankerConfigs((prev) => [...prev, config]);
     setEditRerankerConfig(newrerankerconfig);
   };
 
-  const handleSaveSuccess = (llmConfig: RerankerConfig) => {
-    setRerankerConfigs((prev) =>
-      prev.map((config) => (config.id === llmConfig.id ? llmConfig : config)),
-    );
-    console.log(t('config.model.editRerankerSuccess'), llmConfig);
+  const handleSaveSuccess = (config: RerankerConfig) => {
+    setRerankerConfigs((prev) => prev.map((c) => (c.id === config.id ? config : c)));
     setEditRerankerConfig(newrerankerconfig);
   };
 
-  const handlePageChange = (newPage: number) => {
-    if (newPage < 1 || newPage > totalPages) return;
-    setPage(newPage);
-  };
-
-  const removeModel = async (id: string, model_type: string) => {
+  const removeModel = async (id: string) => {
     setErrorMsg('');
     try {
-      console.log('removeModel: id: ', id, 'model_type: ', model_type);
-      const res = await tenantFetch(`/api/config/${model_type}/${id}`, {
+      const res = await tenantFetch(`/api/config/rerankers/${id}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
 
       if (!res.ok) {
-        setErrorMsg(t('config.model.deleteModelFailed', { modelType: model_type }));
+        setErrorMsg(t('config.model.deleteModelFailed', { modelType: 'Reranker' }));
         return;
       }
-
-      // Delete success, update local state
-      if (model_type === 'rerankers') {
-        setRerankerConfigs((prev) => prev.filter((config) => config.id !== id));
-      }
+      setRerankerConfigs((prev) => prev.filter((c) => c.id !== id));
     } catch (err: any) {
       setErrorMsg(t('config.model.deleteFailed'));
     }
   };
 
-  return (
-    <div id="llm">
-      <div className="grid grid-cols-1 pb-8">
-        <Button
-          onClick={() => {
-            setIsCreateOpen(true);
-            setEditRerankerConfig(newrerankerconfig);
-          }}
-        >
-          {t('config.model.addRerankerModel')}
-        </Button>
-        <RerankerModelDialog
-          isAdd={isCreateOpen ? true : false}
-          isOpen={isEditOpen || isCreateOpen}
-          setIsOpen={(open: boolean) => {
-            if (!open) {
-              setEditRerankerConfig(newrerankerconfig);
-            }
-            setIsEditOpen(open);
-            setIsCreateOpen(open);
-          }}
-          rerankerConfig={editRerankerConfig || newrerankerconfig}
-          onSaveSuccess={(reranker: RerankerConfig) => {
-            if (isCreateOpen) {
-              handleCreateSuccess(reranker);
-            } else {
-              handleSaveSuccess(reranker);
-            }
-          }}
-        />
-      </div>
-      {rerankerconfigs.length > 0 ? (
-        <div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2">
-            {rerankerconfigs.map((reranker) => (
-              <Card
-                key={reranker.id}
-                className="flex flex-col border rounded-lg shadow-sm h-full pt-2 pb-2"
-              >
-                <CardHeader>
-                  <CardTitle className="text-sm font-medium">
-                    <div className="flex items-center gap-3 flex-wrap">
-                      <Badge className="bg-red-100 text-red-800">
-                        {reranker.model_name}
-                      </Badge>
-                    </div>
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="pt-0">
-                  <p className="truncate">{reranker.model_id}</p>
-                  <p className="truncate text-muted-foreground pt-2 text-xs">
-                    {reranker.base_url}
-                  </p>
-                </CardContent>
-                <CardFooter className="mt-auto pt-0 flex justify-end pb-0">
-                  <Button
-                    variant="link"
-                    onClick={() => removeModel(reranker.id, 'rerankers')}
-                    className="text-sm text-primary text-red-600 hover:text-primary/80 underline-offset-4 hover:underline"
-                  >
-                    <TrashIcon className="ml-1" size={16} />
-                  </Button>
+  const openCreate = () => {
+    setIsCreateOpen(true);
+    setEditRerankerConfig(newrerankerconfig);
+  };
 
-                  <Button
-                    variant="link"
-                    className="text-sm text-primary text-blue-600 hover:text-primary/80 underline-offset-4 hover:underline"
-                    onClick={() => {
-                      setEditRerankerConfig(reranker);
-                      setIsEditOpen(true);
-                    }}
-                  >
-                    <Edit className="ml-1" size={16} />
-                  </Button>
-                </CardFooter>
-              </Card>
-            ))}
-          </div>
-          <div className="flex justify-center items-center h-1/10 py-6">
-            <PaginationComponent
-              currentPage={page}
-              totalPages={totalPages}
-              onPageChange={handlePageChange}
-            />
-          </div>
+  return (
+    <section id="reranker" className="section-panel">
+      {/* Section header */}
+      <div className="section-header">
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-primary" />
+          <h2 className="section-title">{t('config.model.tabReranker') || 'Reranker'}</h2>
+          <span className="text-xs text-muted-foreground">· {rerankerconfigs.length}</span>
+        </div>
+        <Button size="sm" variant="outline" onClick={openCreate}>
+          <Plus className="w-4 h-4" />
+          Add
+        </Button>
+      </div>
+
+      <RerankerModelDialog
+        isAdd={isCreateOpen ? true : false}
+        isOpen={isEditOpen || isCreateOpen}
+        setIsOpen={(open: boolean) => {
+          if (!open) {
+            setEditRerankerConfig(newrerankerconfig);
+          }
+          setIsEditOpen(open);
+          setIsCreateOpen(open);
+        }}
+        rerankerConfig={editRerankerConfig || newrerankerconfig}
+        onSaveSuccess={(reranker: RerankerConfig) => {
+          if (isCreateOpen) handleCreateSuccess(reranker);
+          else handleSaveSuccess(reranker);
+        }}
+      />
+
+      {rerankerconfigs.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3">
+          {rerankerconfigs.map((reranker) => (
+            <div key={reranker.id} className="model-card group">
+              {/* Top-right corner: type badge + more menu */}
+              <div className="absolute top-3 right-3 flex items-center gap-2">
+                <span className="type-corner-badge type-reranker">RNK</span>
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger asChild>
+                    <button type="button" className="icon-action-btn" aria-label="More">
+                      <MoreHorizontal className="w-4 h-4" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="menu-compact">
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        setEditRerankerConfig(reranker);
+                        setIsEditOpen(true);
+                      }}
+                    >
+                      <Edit />
+                      {t('common.edit') || 'Edit'}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onSelect={() => removeModel(reranker.id)}
+                    >
+                      <TrashIcon />
+                      {t('common.delete') || 'Delete'}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+
+              <div className="flex items-start gap-3 pr-20">
+                <div className="model-icon type-reranker shrink-0">{(reranker.model_name || 'R').charAt(0)}</div>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-sm truncate" title={reranker.model_id}>
+                    {reranker.model_id}
+                  </div>
+                  <div className="text-xs text-muted-foreground truncate">
+                    {reranker.model_name}
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-1.5 flex-wrap">
+                {reranker.type && (
+                  <Badge className="badge-tech text-[10.5px] py-0">{reranker.type}</Badge>
+                )}
+              </div>
+
+              {reranker.base_url && (
+                <div className="endpoint-text" title={reranker.base_url}>
+                  {reranker.base_url}
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       ) : (
-        <div className="flex justify-center items-center h-1/10 py-6">
-          <h3 className="text-lg font-medium text-gray-700 py-6">
-            {t('config.model.noModelsYet')}
-          </h3>
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <Sparkles className="w-10 h-10 text-muted-foreground/40 mb-2" />
+          <p className="text-sm text-muted-foreground">
+            暂无模型，点击右上角按钮添加
+          </p>
         </div>
       )}
-      <div className="block w-full">
-        {errorMsg !== '' && (
+
+      {errorMsg !== '' && (
+        <div className="block w-full mt-3">
           <Alert variant="destructive">
             <AlertCircleIcon />
             <AlertDescription>
               <p>{errorMsg}</p>
             </AlertDescription>
           </Alert>
-        )}
-      </div>
-    </div>
+        </div>
+      )}
+    </section>
   );
 }

--- a/frontend/app/config/role/page.tsx
+++ b/frontend/app/config/role/page.tsx
@@ -19,13 +19,13 @@ export default function RoleConfigPage() {
     <div id="access-control">
       <div className="flex flex-col h-screen p-6 space-y-6">
         <div className="flex justify-between items-center h-1/10">
-          <h1 className="text-xl font-medium">{t('config.role.title')}</h1>
+          <h1 className="page-title">{t('config.role.title')}</h1>
         </div>
 
         <div className="h-4/5">
           <div className="">
             <Tabs defaultValue="roles">
-              <TabsList className="py-4 bg-muted rounded-lg flex-none">
+              <TabsList className="py-4 tabs-modern flex-none">
                 <TabsTrigger value="roles" className="p-4">
                   {t('config.role.roles')}
                 </TabsTrigger>

--- a/frontend/app/config/search/page.tsx
+++ b/frontend/app/config/search/page.tsx
@@ -3,26 +3,32 @@
 import { Button } from '@/components/ui/button';
 import React, { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { toast } from 'sonner';
-import { Slider } from "@/components/ui/slider"
+import { Slider } from '@/components/ui/slider';
+import { ExternalLink } from 'lucide-react';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
 const ENDPOINT_LIST = [
-  "iqs.cn-zhangjiakou.aliyuncs.com",
-  "iqs-vpc.cn-beijing.aliyuncs.com",
-  "iqs-vpc.cn-zhangjiakou.aliyuncs.com",
-  "iqs-vpc.cn-shanghai.aliyuncs.com",
-  "iqs-vpc.cn-wulanchabu.aliyuncs.com",
-  "iqs-vpc.cn-chengdu.aliyuncs.com",
-  "iqs-vpc.cn-guangzhou.aliyuncs.com",
-  "iqs-vpc.cn-shenzhen.aliyuncs.com",
-  "iqs-vpc.cn-hangzhou.aliyuncs.com",
-]
+  'iqs.cn-zhangjiakou.aliyuncs.com',
+  'iqs-vpc.cn-beijing.aliyuncs.com',
+  'iqs-vpc.cn-zhangjiakou.aliyuncs.com',
+  'iqs-vpc.cn-shanghai.aliyuncs.com',
+  'iqs-vpc.cn-wulanchabu.aliyuncs.com',
+  'iqs-vpc.cn-chengdu.aliyuncs.com',
+  'iqs-vpc.cn-guangzhou.aliyuncs.com',
+  'iqs-vpc.cn-shenzhen.aliyuncs.com',
+  'iqs-vpc.cn-hangzhou.aliyuncs.com',
+];
 
-const MASK_API_KEY = '******'
+const MASK_API_KEY = '******';
 
 export default function SearchConfig() {
   const { t } = useI18n();
@@ -31,14 +37,13 @@ export default function SearchConfig() {
 
   const [aliyunAK, setAliyunAK] = useState('');
   const [aliyunSK, setAliyunSK] = useState('');
-  const [endpoint, setEndpoint] = useState('')
+  const [endpoint, setEndpoint] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const [searchCount, setSearchCount] = useState(10);
   const [tavilyApiKey, setTavilyApiKey] = useState('');
   const [searchEngineType, setSearchEngineType] = useState('aliyun');
   const { tenantFetch } = useTenantFetch();
 
-  // Initialize and load configuration
   useEffect(() => {
     const fetchConfig = async () => {
       try {
@@ -46,30 +51,26 @@ export default function SearchConfig() {
           method: 'GET',
           headers: { 'Content-Type': 'application/json' },
         });
-
         if (!res.ok) throw new Error(t('config.loadError'));
-
         const data = (await res.json()).data[0];
         setAliyunHasKey(!data.is_aliyun_empty);
         setTavilyHasKey(!data.is_tavily_empty);
         setAliyunAK(MASK_API_KEY);
         setAliyunSK(MASK_API_KEY);
-        setEndpoint(data?.endpoint || "")
-        setSearchCount(data?.search_count || 10)
-        setSearchEngineType(data?.type || 'aliyun')
-        setTavilyApiKey(MASK_API_KEY)
+        setEndpoint(data?.endpoint || '');
+        setSearchCount(data?.search_count || 10);
+        setSearchEngineType(data?.type || 'aliyun');
+        setTavilyApiKey(MASK_API_KEY);
       } catch (err: any) {
         toast.error(err.message);
       }
     };
-
     fetchConfig();
   }, []);
-  // Save configuration
+
   const handleSave = async () => {
     try {
       setIsSaving(true);
-
       const update_ak = aliyunAK === MASK_API_KEY ? '' : aliyunAK;
       const update_sk = aliyunSK === MASK_API_KEY ? '' : aliyunSK;
       const update_tavily_api_key = tavilyApiKey === MASK_API_KEY ? '' : tavilyApiKey;
@@ -77,7 +78,6 @@ export default function SearchConfig() {
       const res = await tenantFetch(`/api/config/websearch`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-
         body: JSON.stringify({
           access_key_id: update_ak,
           access_key_secret: update_sk,
@@ -89,7 +89,6 @@ export default function SearchConfig() {
       });
 
       if (!res.ok) throw new Error(t('config.search.saveFailed'));
-
       toast.success(t('config.search.saveSuccess'));
     } catch (err: any) {
       toast.warning(err.message);
@@ -99,137 +98,134 @@ export default function SearchConfig() {
   };
 
   return (
-    <div id="search">
-      <div
-        className={
-          'transition-colors rounded-lg p-4 overflow-hidden duration-200'
-        }
-      >
-        <div className="flex flex-col items-center justify-center py-12 border-2 border-dashed border-gray-200 rounded-xl bg-gray-50">
-          <h2 className="text-xl font-medium text-gray-800">{t('config.search.title')}</h2>
-          <div className="grid gap-4 py-4">
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="endpoint" className="text-right">
-                {t('config.search.selectSearchEngine')}
-              </Label>
-               <div className="col-span-3 flex items-center">
-                <Select
-                  value={searchEngineType}
-                  onValueChange={(value) =>
-                    setSearchEngineType(value)
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder={t('config.search.selectSearchEnginePlaceholder')} />
-                  </SelectTrigger>
-                  <SelectContent>
-                      <SelectItem key='aliyun' value='aliyun'>
-                        {t('config.search.aliyunUniversalSearch')}
-                      </SelectItem>
-                      <SelectItem key='tavily' value='tavily'>
-                        {t('config.search.tavilySearch')}
-                      </SelectItem>
-                  </SelectContent>
-                </Select>
+    <div id="search" className="settings-page">
+      <div className="settings-page-header">
+        <h1 className="page-title">{t('config.search.title')}</h1>
+        <Button size="sm" onClick={handleSave} disabled={isSaving}>
+          {isSaving ? t('config.search.saving') : t('config.search.saveSearchConfig')}
+        </Button>
+      </div>
 
-                <a href={searchEngineType=== 'aliyun' ? "https://help.aliyun.com/document_detail/2870227.html" : "https://www.tavily.com/"} target="_blank" className="ml-4 text-sm text-blue-600 hover:underline">{t('config.search.activationGuide')} </a>
-              </div>
-
+      <div className="settings-page-content">
+        <div className="space-y-6">
+          {/* Engine selector */}
+          <div>
+            <div className="dialog-section-title mb-2">搜索引擎</div>
+            <div className="flex items-center gap-3">
+              <Select value={searchEngineType} onValueChange={setSearchEngineType}>
+                <SelectTrigger className="flex-1">
+                  <SelectValue placeholder={t('config.search.selectSearchEnginePlaceholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="aliyun">{t('config.search.aliyunUniversalSearch')}</SelectItem>
+                  <SelectItem value="tavily">{t('config.search.tavilySearch')}</SelectItem>
+                </SelectContent>
+              </Select>
+              <a
+                href={
+                  searchEngineType === 'aliyun'
+                    ? 'https://help.aliyun.com/document_detail/2870227.html'
+                    : 'https://www.tavily.com/'
+                }
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-primary hover:underline inline-flex items-center gap-1 whitespace-nowrap"
+              >
+                {t('config.search.activationGuide')}
+                <ExternalLink className="w-3 h-3" />
+              </a>
             </div>
-            { searchEngineType === 'aliyun' && (
-              <div className="gap-4">
-              <div className="grid grid-cols-4 items-center gap-4">
-                <Label htmlFor="endpoint" className="text-right">
-                  {t('config.search.universalSearchEndpoint')}
-                </Label>
-                <div className="col-span-3 flex items-center">
-                  <Select
-                    value={endpoint}
-                    onValueChange={(value) =>
-                      setEndpoint(value)
-                    }
-                  >
+          </div>
+
+          {searchEngineType === 'aliyun' && (
+            <div>
+              <div className="dialog-section-title mb-2">Aliyun IQS 凭证</div>
+              <div className="space-y-4">
+                <div>
+                  <label className="form-label">
+                    {t('config.search.universalSearchEndpoint')}
+                  </label>
+                  <Select value={endpoint} onValueChange={setEndpoint}>
                     <SelectTrigger>
                       <SelectValue placeholder={t('config.search.selectRegionPlaceholder')} />
                     </SelectTrigger>
                     <SelectContent>
-                      {ENDPOINT_LIST.map((endpoint) => (
-                        <SelectItem key={endpoint} value={endpoint}>
-                          {endpoint}
+                      {ENDPOINT_LIST.map((ep) => (
+                        <SelectItem key={ep} value={ep}>
+                          {ep}
                         </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
                 </div>
-              </div>
-              <div className="grid grid-cols-4 items-center gap-4 pt-4">
-                <Label htmlFor="aliyun_ak" className="text-right">
-                  {t('config.search.accessKeyId')}
-                </Label>
-                <div className="col-span-3 flex items-center">
-                  <Input
-                    id="aliyun_ak"
-                    defaultValue={aliyunHasKey ? '******' : ''}
-                    type="password"
-                    onChange={(e) => setAliyunAK(e.target.value)}
-                    placeholder={t('config.search.accessKeyIdPlaceholder')}
-                    className="col-span-3"
-                  />
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label htmlFor="aliyun_ak" className="form-label">
+                      {t('config.search.accessKeyId')}
+                    </label>
+                    <Input
+                      id="aliyun_ak"
+                      defaultValue={aliyunHasKey ? '******' : ''}
+                      type="password"
+                      onChange={(e) => setAliyunAK(e.target.value)}
+                      placeholder={t('config.search.accessKeyIdPlaceholder')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="aliyun_sk" className="form-label">
+                      {t('config.search.accessKeySecret')}
+                    </label>
+                    <Input
+                      id="aliyun_sk"
+                      defaultValue={aliyunHasKey ? '******' : ''}
+                      type="password"
+                      onChange={(e) => setAliyunSK(e.target.value)}
+                      placeholder={t('config.search.accessKeySecretPlaceholder')}
+                    />
+                  </div>
                 </div>
-              </div>
-              <div className="grid grid-cols-4 items-center gap-4 pt-4">
-                <Label htmlFor="aliyun_sk" className="text-right">
-                  {t('config.search.accessKeySecret')}
-                </Label>
-                <div className="col-span-3 flex items-center">
-                  <Input
-                    id="aliyun_sk"
-                    defaultValue={aliyunHasKey ? '******' : ''}
-                    type="password"
-                    onChange={(e) => setAliyunSK(e.target.value)}
-                    placeholder={t('config.search.accessKeySecretPlaceholder')}
-                    className="col-span-3"
-                  />
-                </div>
-              </div>
-              </div>
-            )}
-           { searchEngineType === 'tavily' && (
-              <div className="grid grid-cols-4 items-center gap-4">
-                <Label htmlFor="tavily_key" className="text-right">
-                {t('config.search.tavilyApiKey')}
-                </Label>
-                <div className="col-span-3 flex items-center">
-                  <Input
-                    id="tavily_key"
-                    defaultValue={tavilyHasKey ? '******' : ''}
-                    type="password"
-                    onChange={(e) => setTavilyApiKey(e.target.value)}
-                    placeholder={t('config.search.tavilyApiKeyPlaceholder')}
-                    className="col-span-3"
-                  />
-                </div>
-              </div>
-
-           )}
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="search_count" className="text-right">
-              {t('config.search.searchResultCount', { count: searchCount })}
-              </Label>
-              <div className="col-span-3 flex items-center">
-                <Slider defaultValue={[10]} max={20} min={1} step={1} onValueChange={(value: number[]) => setSearchCount(value[0])} />
               </div>
             </div>
+          )}
 
+          {searchEngineType === 'tavily' && (
+            <div>
+              <div className="dialog-section-title mb-2">Tavily 凭证</div>
+              <div>
+                <label htmlFor="tavily_key" className="form-label">
+                  {t('config.search.tavilyApiKey')}
+                </label>
+                <Input
+                  id="tavily_key"
+                  defaultValue={tavilyHasKey ? '******' : ''}
+                  type="password"
+                  onChange={(e) => setTavilyApiKey(e.target.value)}
+                  placeholder={t('config.search.tavilyApiKeyPlaceholder')}
+                />
+              </div>
+            </div>
+          )}
+
+          <div>
+            <div className="dialog-section-title mb-2">搜索参数</div>
+            <div className="form-row-inline">
+              <div className="form-row-inline-label">
+                <span className="title">
+                  {t('config.search.searchResultCount', { count: searchCount })}
+                </span>
+                <span className="hint">每次搜索返回的最多结果数 (1–20)</span>
+              </div>
+              <div className="w-48">
+                <Slider
+                  value={[searchCount]}
+                  max={20}
+                  min={1}
+                  step={1}
+                  onValueChange={(v: number[]) => setSearchCount(v[0])}
+                />
+              </div>
+            </div>
           </div>
-
-          <Button
-            onClick={handleSave}
-            disabled={isSaving}
-            className="mt-4 px-4 py-2 text-white rounded-lg transition-colors"
-          >
-            {isSaving ? t('config.search.saving') : t('config.search.saveSearchConfig')}
-          </Button>
         </div>
       </div>
     </div>

--- a/frontend/app/config/tracing/page.tsx
+++ b/frontend/app/config/tracing/page.tsx
@@ -3,9 +3,9 @@
 import { Button } from '@/components/ui/button';
 import React, { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Checkbox } from '@/components/ui/checkbox';
+import { Switch } from '@/components/ui/switch';
 import { toast } from 'sonner';
+import { ExternalLink } from 'lucide-react';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
@@ -15,25 +15,18 @@ export default function TracingConfig() {
   const [token, setToken] = useState('');
   const [serviceName, setServiceName] = useState('');
   const [traceEnabled, setTraceEnabled] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-
   const [error, setError] = useState('');
-
   const { tenantFetch } = useTenantFetch();
-  // Initialize and load configuration
+
   useEffect(() => {
     const fetchConfig = async () => {
       try {
-        setIsLoading(true);
-
         const res = await tenantFetch(`/api/config/trace`, {
           method: 'GET',
           headers: { 'Content-Type': 'application/json' },
         });
-
         if (!res.ok) throw new Error(t('config.loadError'));
-
         const data = (await res.json()).data;
         setEndpoint(data['endpoint'] || '');
         setToken(data['token'] || '');
@@ -41,14 +34,11 @@ export default function TracingConfig() {
         setTraceEnabled(data['enabled'] || false);
       } catch (err: any) {
         toast.error(err.message);
-      } finally {
-        setIsLoading(false);
       }
     };
-
     fetchConfig();
   }, []);
-  // Save configuration
+
   const handleSave = async () => {
     if (!endpoint || !token || !serviceName) {
       setError(t('config.tracing.fieldsRequired'));
@@ -57,7 +47,6 @@ export default function TracingConfig() {
     try {
       setIsSaving(true);
       setError('');
-
       const res = await tenantFetch(`/api/config/trace`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -68,95 +57,97 @@ export default function TracingConfig() {
           enabled: traceEnabled,
         }),
       });
-
       if (!res.ok) throw new Error(t('config.tracing.saveFailed'));
-
       toast.success(t('config.tracing.saveSuccess'));
     } catch (err: any) {
-        toast.error(err.message);
+      toast.error(err.message);
     } finally {
       setIsSaving(false);
     }
   };
 
   return (
-    <div id="tracing">
-      <div
-        className={
-          'transition-colors rounded-lg p-4 overflow-hidden duration-200'
-        }
-      >
-        <div className="flex flex-col items-center justify-center py-12 border-2 border-dashed border-gray-200 rounded-xl bg-gray-50">
-          <h2 className="text-xl font-medium text-gray-800">
-            {t('config.tracing.aliyunTracingConfig')}
-          </h2>
-          <a
-            href="https://help.aliyun.com/zh/opentelemetry/quick-start?spm=a2c4g.11186623.help-menu-90275.d_1.15c45dc7tG5ukV#prereq-3jq-3as-xo9"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-600 hover:underline text-sm"
-          >
-            {t('config.tracing.howToGetInfo')}
-          </a>
+    <div id="tracing" className="settings-page">
+      <div className="settings-page-header">
+        <h1 className="page-title">{t('config.tracing.aliyunTracingConfig')}</h1>
+        <Button size="sm" onClick={handleSave} disabled={isSaving}>
+          {isSaving ? t('config.tracing.saving') : t('config.tracing.saveTracingConfig')}
+        </Button>
+      </div>
 
-          <div className="grid gap-4 py-4 max-w-xl w-full mx-auto">
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="endpoint">{t('config.tracing.endpoint')}</Label>
-              <div className="col-span-3 flex items-center">
+      <div className="settings-page-content">
+        <div className="space-y-6">
+          <div>
+            <a
+              href="https://help.aliyun.com/zh/opentelemetry/quick-start?spm=a2c4g.11186623.help-menu-90275.d_1.15c45dc7tG5ukV#prereq-3jq-3as-xo9"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+            >
+              {t('config.tracing.howToGetInfo')}
+              <ExternalLink className="w-3 h-3" />
+            </a>
+          </div>
+
+          <div>
+            <div className="dialog-section-title mb-2">OpenTelemetry 端点</div>
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="endpoint" className="form-label">
+                  {t('config.tracing.endpoint')}
+                  <span className="required">*</span>
+                </label>
                 <Input
                   id="endpoint"
                   value={endpoint}
                   onChange={(e) => setEndpoint(e.target.value)}
                   placeholder={t('config.tracing.endpointPlaceholder')}
-                  className="col-span-3"
                 />
               </div>
-            </div>
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="token">Token</Label>
-              <div className="col-span-3 flex items-center">
+
+              <div>
+                <label htmlFor="token" className="form-label">
+                  Token<span className="required">*</span>
+                </label>
                 <Input
                   id="token"
                   value={token}
                   onChange={(e) => setToken(e.target.value)}
                   placeholder={t('config.tracing.tokenPlaceholder')}
-                  className="col-span-3"
                 />
               </div>
-            </div>
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="serivceName">{t('config.tracing.serviceName')}</Label>
-              <div className="col-span-3 flex items-center">
+
+              <div>
+                <label htmlFor="serivceName" className="form-label">
+                  {t('config.tracing.serviceName')}
+                  <span className="required">*</span>
+                </label>
                 <Input
                   id="serivceName"
                   value={serviceName}
                   onChange={(e) => setServiceName(e.target.value)}
                   placeholder={t('config.tracing.serviceNamePlaceholder')}
-                  className="col-span-3"
                 />
               </div>
             </div>
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="traceEnabled">{t('config.tracing.isEnabled')}</Label>
-              <Checkbox
+          </div>
+
+          <div>
+            <div className="dialog-section-title mb-2">追踪开关</div>
+            <div className="form-row-inline">
+              <div className="form-row-inline-label">
+                <span className="title">{t('config.tracing.isEnabled')}</span>
+                <span className="hint">开启后系统请求将上报至配置的 OpenTelemetry Endpoint</span>
+              </div>
+              <Switch
                 id="traceEnabled"
                 checked={traceEnabled || false}
-                onCheckedChange={(checkedState) => {
-                  const isChecked = checkedState === true;
-                  setTraceEnabled(isChecked);
-                }}
-                className="col-span-3"
+                onCheckedChange={(v) => setTraceEnabled(v === true)}
               />
             </div>
           </div>
-          <Button
-            onClick={handleSave}
-            disabled={isSaving}
-            className="mt-4 px-4 py-2 text-white rounded-lg transition-colors"
-          >
-            {isSaving ? t('config.tracing.saving') : t('config.tracing.saveTracingConfig')}
-          </Button>
-          {error && <p className="text-red-500 mt-2">{error}</p>}
+
+          {error && <p className="text-destructive text-sm">{error}</p>}
         </div>
       </div>
     </div>

--- a/frontend/app/config/vectordb/page.tsx
+++ b/frontend/app/config/vectordb/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
   SelectContent,
@@ -8,8 +7,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Label } from "@/components/ui/label";
-import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Key, useEffect, useState } from "react";
 import { PostgresqlConfig, PostgresqlForm } from "./forms/postgresql";
@@ -159,56 +156,65 @@ export default function VectorDBConsole() {
   };
 
   return (
-    <Card className="w-full max-w-3xl mx-auto">
-      <CardHeader>
-        <CardTitle>{t('config.vectordb.title')}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        {
-            loading ? <Skeleton className="h-12 w-12 rounded-full" /> :
-        <div className="space-y-6">
-          <div className="space-y-2">
-            <Label>{t('config.vectordb.dbType')}</Label>
-            <Select value={dbType} onValueChange={(v) => {
-                cache.set(dbType, db);
-                setDbType(v as DBType);
-                setDb(cache.get(v as DBType) || {});
-            }}>
-              <SelectTrigger>
-                <SelectValue placeholder={t('config.vectordb.selectDbType')} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="local">{t('config.vectordb.localChroma')}</SelectItem>
-                <SelectItem value="postgresql">PostgreSQL</SelectItem>
-                <SelectItem value="milvus">Milvus</SelectItem>
-                <SelectItem value="elasticsearch">Elasticsearch</SelectItem>
-                <SelectItem value="hologres">Hologres</SelectItem>
-                <SelectItem value="opensearch">Opensearch</SelectItem>
-                <SelectItem value="tablestore">Tablestore</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <Separator />
-
-          {renderForm()}
-
-          <div className="flex gap-4 pt-4">
-            <Button variant="outline" onClick={testConnection}> 
-                {connectionTesting ? (
-                          <>
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            {t('config.vectordb.testing')}
-                          </>
-                        ) : (
-                          <>{t('config.vectordb.testConnection')}</>
-                        )}</Button>
-                        
-            <Button onClick={saveConnection}>{t('common.save')}</Button>
-          </div>
+    <div id="vectordb" className="settings-page">
+      <div className="settings-page-header">
+        <h1 className="page-title">{t('config.vectordb.title')}</h1>
+        <div className="flex gap-2">
+          <Button size="sm" variant="outline" onClick={testConnection} disabled={connectionTesting}>
+            {connectionTesting ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                {t('config.vectordb.testing')}
+              </>
+            ) : (
+              t('config.vectordb.testConnection')
+            )}
+          </Button>
+          <Button size="sm" onClick={saveConnection}>
+            {t('common.save')}
+          </Button>
         </div>
-        }
-      </CardContent>
-    </Card>
+      </div>
+
+      <div className="settings-page-content">
+        {loading ? (
+          <Skeleton className="h-12 w-12 rounded-full" />
+        ) : (
+          <div className="space-y-6">
+            <div>
+              <div className="dialog-section-title mb-2">数据库类型</div>
+              <Select
+                value={dbType}
+                onValueChange={(v) => {
+                  cache.set(dbType, db);
+                  setDbType(v as DBType);
+                  setDb(cache.get(v as DBType) || {});
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t('config.vectordb.selectDbType')} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="local">{t('config.vectordb.localChroma')}</SelectItem>
+                  <SelectItem value="postgresql">PostgreSQL</SelectItem>
+                  <SelectItem value="milvus">Milvus</SelectItem>
+                  <SelectItem value="elasticsearch">Elasticsearch</SelectItem>
+                  <SelectItem value="hologres">Hologres</SelectItem>
+                  <SelectItem value="opensearch">Opensearch</SelectItem>
+                  <SelectItem value="tablestore">Tablestore</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {dbType !== 'local' && (
+              <div>
+                <div className="dialog-section-title mb-2">连接配置</div>
+                {renderForm()}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -62,63 +62,83 @@ html {
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
+  /* Background & Foreground — subtle blue-tinted white */
+  --background: oklch(0.985 0.002 250);
+  --foreground: oklch(0.145 0.014 265);
+  /* Card */
+  --card: oklch(0.995 0.001 250);
+  --card-foreground: oklch(0.145 0.014 265);
+  /* Popover */
+  --popover: oklch(0.995 0.001 250);
+  --popover-foreground: oklch(0.145 0.014 265);
+  /* Primary — vivid indigo-blue */
+  --primary: oklch(0.488 0.180 264);
+  --primary-foreground: oklch(0.985 0.002 250);
+  /* Secondary */
+  --secondary: oklch(0.955 0.008 260);
+  --secondary-foreground: oklch(0.205 0.015 265);
+  /* Muted */
+  --muted: oklch(0.955 0.008 260);
+  --muted-foreground: oklch(0.556 0.020 265);
+  /* Accent */
+  --accent: oklch(0.940 0.012 260);
+  --accent-foreground: oklch(0.205 0.015 265);
+  /* Destructive */
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.705 0.015 286.067);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.705 0.015 286.067);
+  /* Border & Input — blue-tinted */
+  --border: oklch(0.915 0.008 260);
+  --input: oklch(0.915 0.008 260);
+  /* Ring — matches primary */
+  --ring: oklch(0.488 0.180 264);
+  /* Chart colors */
+  --chart-1: oklch(0.588 0.200 264);
+  --chart-2: oklch(0.650 0.170 170);
+  --chart-3: oklch(0.700 0.150 145);
+  --chart-4: oklch(0.750 0.160 80);
+  --chart-5: oklch(0.600 0.200 310);
+  /* Sidebar — refined light, subtly differentiated from main */
+  --sidebar: oklch(0.975 0.004 260);
+  --sidebar-foreground: oklch(0.205 0.015 265);
+  --sidebar-primary: oklch(0.488 0.180 264);
+  --sidebar-primary-foreground: oklch(0.985 0.002 250);
+  --sidebar-accent: oklch(0.935 0.010 260);
+  --sidebar-accent-foreground: oklch(0.205 0.015 265);
+  --sidebar-border: oklch(0.915 0.008 260);
+  --sidebar-ring: oklch(0.488 0.180 264);
 }
 
 .dark {
-  --background: oklch(0.141 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 286.32);
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
+  --background: oklch(0.145 0.014 265);
+  --foreground: oklch(0.955 0.008 260);
+  --card: oklch(0.185 0.018 265);
+  --card-foreground: oklch(0.955 0.008 260);
+  --popover: oklch(0.185 0.018 265);
+  --popover-foreground: oklch(0.955 0.008 260);
+  --primary: oklch(0.620 0.180 264);
+  --primary-foreground: oklch(0.145 0.014 265);
+  --secondary: oklch(0.230 0.020 265);
+  --secondary-foreground: oklch(0.955 0.008 260);
+  --muted: oklch(0.230 0.020 265);
+  --muted-foreground: oklch(0.650 0.020 265);
+  --accent: oklch(0.260 0.025 265);
+  --accent-foreground: oklch(0.955 0.008 260);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.552 0.016 285.938);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
+  --border: oklch(0.280 0.018 265);
+  --input: oklch(0.280 0.018 265);
+  --ring: oklch(0.620 0.180 264);
+  --chart-1: oklch(0.588 0.200 264);
+  --chart-2: oklch(0.650 0.170 170);
+  --chart-3: oklch(0.700 0.150 145);
+  --chart-4: oklch(0.750 0.160 80);
+  --chart-5: oklch(0.600 0.200 310);
+  --sidebar: oklch(0.130 0.016 265);
+  --sidebar-foreground: oklch(0.850 0.012 260);
+  --sidebar-primary: oklch(0.620 0.180 264);
+  --sidebar-primary-foreground: oklch(0.145 0.014 265);
+  --sidebar-accent: oklch(0.200 0.020 265);
+  --sidebar-accent-foreground: oklch(0.850 0.012 260);
+  --sidebar-border: oklch(0.230 0.016 265);
+  --sidebar-ring: oklch(0.620 0.180 264);
 }
 
 @layer base {
@@ -130,49 +150,761 @@ html {
   }
 }
 
-/* modern-markdown.css */
+/* ===== PAI-RAG Tech Theme Enhancements ===== */
+
+/* Main content gradient background — subtle diagonal tint */
+.main-gradient-bg {
+  background:
+    radial-gradient(ellipse 80% 60% at 85% 15%, oklch(0.488 0.180 264 / 0.06), transparent 60%),
+    radial-gradient(ellipse 70% 50% at 15% 90%, oklch(0.600 0.200 310 / 0.05), transparent 60%),
+    linear-gradient(180deg, oklch(0.995 0.001 250), oklch(0.980 0.005 260));
+}
+.dark .main-gradient-bg {
+  background:
+    radial-gradient(ellipse 80% 60% at 85% 15%, oklch(0.620 0.180 264 / 0.08), transparent 60%),
+    radial-gradient(ellipse 70% 50% at 15% 90%, oklch(0.600 0.200 310 / 0.06), transparent 60%),
+    linear-gradient(180deg, oklch(0.145 0.014 265), oklch(0.170 0.018 265));
+}
+
+/* Logo icon — purple/indigo rounded square */
+.logo-icon {
+  background: linear-gradient(135deg, oklch(0.600 0.200 285), oklch(0.488 0.180 264));
+  color: white;
+  box-shadow: 0 2px 8px oklch(0.488 0.180 264 / 0.25);
+}
+
+/* Keyboard shortcut badge */
+.kbd-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 4px;
+  background: oklch(0.955 0.008 260);
+  border: 1px solid oklch(0.915 0.008 260);
+  color: oklch(0.556 0.020 265);
+  font-size: 10.5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  line-height: 1;
+}
+.dark .kbd-badge {
+  background: oklch(0.230 0.020 265);
+  border-color: oklch(0.280 0.018 265);
+  color: oklch(0.700 0.015 265);
+}
+
+/* Composer — rounded, elevated, with focus glow */
+.composer-box {
+  border-radius: 20px;
+  border: 1px solid oklch(0.915 0.008 260);
+  background: oklch(1 0 0);
+  box-shadow: 0 1px 2px oklch(0.145 0.014 265 / 0.04);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.composer-box:focus-within {
+  border-color: oklch(0.488 0.180 264 / 0.5);
+  box-shadow:
+    0 0 0 4px oklch(0.488 0.180 264 / 0.10),
+    0 2px 8px oklch(0.488 0.180 264 / 0.08);
+}
+.dark .composer-box {
+  background: oklch(0.185 0.018 265);
+  border-color: oklch(0.280 0.018 265);
+}
+.dark .composer-box:focus-within {
+  border-color: oklch(0.620 0.180 264 / 0.6);
+  box-shadow:
+    0 0 0 4px oklch(0.620 0.180 264 / 0.12),
+    0 2px 10px oklch(0.620 0.180 264 / 0.10);
+}
+
+/* Circular send button */
+.send-btn-circle {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: oklch(0.488 0.180 264);
+  color: white;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s ease, transform 0.15s ease;
+}
+.send-btn-circle:hover {
+  background: oklch(0.440 0.180 264);
+  transform: translateY(-1px);
+}
+.send-btn-circle:disabled {
+  background: oklch(0.800 0.020 265);
+  cursor: not-allowed;
+  transform: none;
+}
+.dark .send-btn-circle {
+  background: oklch(0.620 0.180 264);
+}
+.dark .send-btn-circle:hover {
+  background: oklch(0.680 0.180 264);
+}
+
+/* Suggestion pill */
+.suggest-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid oklch(0.915 0.008 260);
+  background: oklch(1 0 0 / 0.7);
+  backdrop-filter: blur(8px);
+  transition: all 0.2s ease;
+  font-size: 13px;
+  color: oklch(0.350 0.020 265);
+}
+.suggest-pill:hover {
+  border-color: oklch(0.488 0.180 264 / 0.3);
+  background: oklch(1 0 0);
+  box-shadow: 0 2px 12px oklch(0.488 0.180 264 / 0.08);
+  color: oklch(0.205 0.015 265);
+}
+.dark .suggest-pill {
+  background: oklch(0.185 0.018 265 / 0.6);
+  border-color: oklch(0.280 0.018 265);
+  color: oklch(0.800 0.012 260);
+}
+.dark .suggest-pill:hover {
+  background: oklch(0.185 0.018 265);
+  border-color: oklch(0.620 0.180 264 / 0.4);
+  color: oklch(0.955 0.008 260);
+}
+
+/* Section panel — simpler than config-panel, no gradient top bar */
+.section-panel {
+  border-radius: 14px;
+  border: 1px solid oklch(0.915 0.008 260);
+  background: oklch(1 0 0 / 0.6);
+  padding: 16px 18px;
+  transition: border-color 0.2s ease;
+}
+.dark .section-panel {
+  background: oklch(0.185 0.018 265 / 0.5);
+  border-color: oklch(0.280 0.018 265);
+}
+
+/* Section header bar (inside section-panel) */
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid oklch(0.915 0.008 260);
+}
+.dark .section-header {
+  border-bottom-color: oklch(0.280 0.018 265);
+}
+
+/* ==== Model card — refined layout ==== */
+.model-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid oklch(0.915 0.008 260);
+  background: oklch(1 0 0);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+.model-card:hover {
+  border-color: oklch(0.488 0.180 264 / 0.35);
+  box-shadow: 0 6px 20px oklch(0.488 0.180 264 / 0.08);
+}
+.dark .model-card {
+  background: oklch(0.185 0.018 265);
+  border-color: oklch(0.280 0.018 265);
+}
+.dark .model-card:hover {
+  border-color: oklch(0.620 0.180 264 / 0.4);
+  box-shadow: 0 6px 24px oklch(0.620 0.180 264 / 0.12);
+}
+
+/* Brand-icon square for model cards (renders first letter of model) */
+.model-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, oklch(0.488 0.180 264 / 0.18), oklch(0.600 0.200 285 / 0.18));
+  color: oklch(0.488 0.180 264);
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+  border: 1px solid oklch(0.488 0.180 264 / 0.15);
+  flex-shrink: 0;
+  text-transform: uppercase;
+}
+.dark .model-icon {
+  background: linear-gradient(135deg, oklch(0.620 0.180 264 / 0.22), oklch(0.600 0.200 285 / 0.22));
+  color: oklch(0.720 0.180 264);
+  border-color: oklch(0.620 0.180 264 / 0.25);
+}
+
+/* Type variants — differentiate LLM / Embedding / Reranker */
+.model-icon.type-llm {
+  background: linear-gradient(135deg, oklch(0.488 0.180 264 / 0.18), oklch(0.600 0.200 285 / 0.18));
+  color: oklch(0.488 0.180 264);
+  border-color: oklch(0.488 0.180 264 / 0.18);
+}
+.dark .model-icon.type-llm {
+  color: oklch(0.720 0.180 264);
+  border-color: oklch(0.620 0.180 264 / 0.25);
+}
+
+.model-icon.type-embedding {
+  background: linear-gradient(135deg, oklch(0.650 0.170 170 / 0.18), oklch(0.700 0.150 190 / 0.18));
+  color: oklch(0.500 0.150 170);
+  border-color: oklch(0.650 0.170 170 / 0.22);
+}
+.dark .model-icon.type-embedding {
+  color: oklch(0.780 0.150 170);
+  border-color: oklch(0.650 0.170 170 / 0.28);
+}
+
+.model-icon.type-reranker {
+  background: linear-gradient(135deg, oklch(0.750 0.160 80 / 0.22), oklch(0.780 0.170 60 / 0.22));
+  color: oklch(0.530 0.150 65);
+  border-color: oklch(0.750 0.160 80 / 0.28);
+}
+.dark .model-icon.type-reranker {
+  color: oklch(0.820 0.160 75);
+  border-color: oklch(0.750 0.160 80 / 0.32);
+}
+
+/* Top-right type label on card */
+.type-corner-badge {
+  min-width: 22px;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 6px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  line-height: 1;
+}
+.type-corner-badge.type-llm {
+  background: oklch(0.488 0.180 264);
+}
+.type-corner-badge.type-embedding {
+  background: oklch(0.550 0.150 170);
+}
+.type-corner-badge.type-reranker {
+  background: oklch(0.620 0.150 65);
+}
+
+/* Monospace endpoint line */
+.endpoint-text {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  color: oklch(0.556 0.020 265);
+  padding: 6px 8px;
+  background: oklch(0.955 0.008 260);
+  border-radius: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dark .endpoint-text {
+  background: oklch(0.230 0.020 265);
+  color: oklch(0.700 0.015 265);
+}
+
+/* Icon action button (edit/delete) */
+.icon-action-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: oklch(0.556 0.020 265);
+  transition: background-color 0.15s ease, color 0.15s ease;
+  cursor: pointer;
+}
+.icon-action-btn:hover {
+  background: oklch(0.955 0.008 260);
+  color: oklch(0.488 0.180 264);
+}
+.icon-action-btn.danger:hover {
+  background: oklch(0.577 0.245 27.325 / 0.1);
+  color: oklch(0.577 0.245 27.325);
+}
+.dark .icon-action-btn {
+  color: oklch(0.700 0.015 265);
+}
+.dark .icon-action-btn:hover {
+  background: oklch(0.260 0.025 265);
+  color: oklch(0.720 0.180 264);
+}
+.dark .icon-action-btn.danger:hover {
+  background: oklch(0.704 0.191 22.216 / 0.15);
+  color: oklch(0.780 0.191 22);
+}
+
+/* Compact dropdown menu — smaller font, tighter padding, rounded card */
+.menu-compact {
+  min-width: 5rem !important;
+  padding: 3px !important;
+  border-radius: 8px !important;
+  box-shadow: 0 6px 16px oklch(0.145 0.014 265 / 0.10),
+              0 1px 3px oklch(0.145 0.014 265 / 0.05) !important;
+}
+.menu-compact [data-slot="dropdown-menu-item"] {
+  font-size: 11.5px;
+  padding: 4px 7px;
+  gap: 6px;
+  border-radius: 5px;
+  min-height: 0;
+}
+.menu-compact [data-slot="dropdown-menu-item"] svg {
+  width: 11px !important;
+  height: 11px !important;
+}
+
+/* Setting page wrapper (standard layout for config sub-pages) */
+.settings-page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  padding: 20px 32px 24px;
+  gap: 20px;
+  overflow: hidden;
+}
+.settings-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  width: 100%;
+  max-width: 768px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.settings-page-content {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 4px;
+  width: 100%;
+  max-width: 768px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ==== Dialog form styles ==== */
+
+/* Form field label — top-aligned, no required star stacking */
+.form-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: oklch(0.350 0.020 265);
+  margin-bottom: 6px;
+}
+.dark .form-label {
+  color: oklch(0.750 0.015 265);
+}
+.form-label .required {
+  color: oklch(0.577 0.245 27.325);
+  font-size: 13px;
+  line-height: 1;
+}
+
+/* Inline field row: label on left, control on right */
+.form-row-inline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: oklch(0.970 0.005 260);
+  transition: background-color 0.15s ease;
+}
+.form-row-inline:hover {
+  background: oklch(0.955 0.008 260);
+}
+.dark .form-row-inline {
+  background: oklch(0.220 0.020 265);
+}
+.dark .form-row-inline:hover {
+  background: oklch(0.240 0.022 265);
+}
+.form-row-inline-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.form-row-inline-label .title {
+  font-size: 13px;
+  font-weight: 500;
+  color: oklch(0.205 0.015 265);
+}
+.form-row-inline-label .hint {
+  font-size: 11.5px;
+  color: oklch(0.556 0.020 265);
+}
+.dark .form-row-inline-label .title {
+  color: oklch(0.955 0.008 260);
+}
+.dark .form-row-inline-label .hint {
+  color: oklch(0.650 0.020 265);
+}
+
+/* Section heading inside dialogs */
+.dialog-section-title {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: oklch(0.556 0.020 265);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+.dark .dialog-section-title {
+  color: oklch(0.650 0.020 265);
+}
+
+/* ==== Config/Settings pages shared styles ==== */
+
+/* Modern panel replacing dashed-gray container */
+.config-panel {
+  border-radius: 16px;
+  border: 1px solid oklch(0.915 0.008 260);
+  background: oklch(1 0 0 / 0.7);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 1px 3px oklch(0.145 0.014 265 / 0.04);
+  padding: 24px;
+  position: relative;
+  overflow: hidden;
+}
+.config-panel::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, oklch(0.488 0.180 264 / 0.5), transparent);
+}
+.dark .config-panel {
+  background: oklch(0.185 0.018 265 / 0.6);
+  border-color: oklch(0.280 0.018 265);
+}
+.dark .config-panel::before {
+  background: linear-gradient(90deg, transparent, oklch(0.620 0.180 264 / 0.6), transparent);
+}
+
+/* Page title with accent bar */
+.page-title {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: oklch(0.145 0.014 265);
+  position: relative;
+  padding-left: 12px;
+}
+.page-title::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 10%;
+  bottom: 10%;
+  width: 3px;
+  border-radius: 3px;
+  background: linear-gradient(180deg, oklch(0.488 0.180 264), oklch(0.600 0.200 285));
+}
+.dark .page-title {
+  color: oklch(0.955 0.008 260);
+}
+
+/* Section title (smaller) */
+.section-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: oklch(0.205 0.015 265);
+}
+.dark .section-title {
+  color: oklch(0.955 0.008 260);
+}
+
+/* Semantic status badges */
+.badge-success {
+  background: oklch(0.700 0.150 145 / 0.12);
+  color: oklch(0.450 0.150 145);
+  border: 1px solid oklch(0.700 0.150 145 / 0.25);
+}
+.dark .badge-success {
+  background: oklch(0.700 0.150 145 / 0.18);
+  color: oklch(0.780 0.150 145);
+  border-color: oklch(0.700 0.150 145 / 0.30);
+}
+
+.badge-warning {
+  background: oklch(0.750 0.160 80 / 0.14);
+  color: oklch(0.520 0.150 65);
+  border: 1px solid oklch(0.750 0.160 80 / 0.30);
+}
+.dark .badge-warning {
+  background: oklch(0.750 0.160 80 / 0.18);
+  color: oklch(0.820 0.160 80);
+  border-color: oklch(0.750 0.160 80 / 0.30);
+}
+
+.badge-danger {
+  background: oklch(0.577 0.245 27.325 / 0.10);
+  color: oklch(0.500 0.220 27);
+  border: 1px solid oklch(0.577 0.245 27.325 / 0.25);
+}
+.dark .badge-danger {
+  background: oklch(0.704 0.191 22.216 / 0.18);
+  color: oklch(0.780 0.191 22);
+  border-color: oklch(0.704 0.191 22 / 0.30);
+}
+
+.badge-neutral {
+  background: oklch(0.955 0.008 260);
+  color: oklch(0.450 0.020 265);
+  border: 1px solid oklch(0.915 0.008 260);
+}
+.dark .badge-neutral {
+  background: oklch(0.230 0.020 265);
+  color: oklch(0.700 0.015 265);
+  border-color: oklch(0.280 0.018 265);
+}
+
+/* Modern tabs bar */
+.tabs-modern {
+  background: oklch(0.955 0.008 260 / 0.5);
+  border: 1px solid oklch(0.915 0.008 260);
+  border-radius: 12px;
+  backdrop-filter: blur(6px);
+}
+.dark .tabs-modern {
+  background: oklch(0.230 0.020 265 / 0.5);
+  border-color: oklch(0.280 0.018 265);
+}
+
+/* Modern table row hover */
+.table-modern tbody tr {
+  transition: background-color 0.15s ease;
+}
+.table-modern tbody tr:hover {
+  background-color: oklch(0.488 0.180 264 / 0.04);
+}
+.dark .table-modern tbody tr:hover {
+  background-color: oklch(0.620 0.180 264 / 0.06);
+}
+.table-modern thead {
+  background: linear-gradient(180deg, oklch(0.955 0.008 260 / 0.8), oklch(0.955 0.008 260 / 0.3));
+}
+.dark .table-modern thead {
+  background: linear-gradient(180deg, oklch(0.230 0.020 265 / 0.7), oklch(0.230 0.020 265 / 0.3));
+}
+
+/* Section divider with gradient */
+.gradient-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, oklch(0.488 0.180 264 / 0.3), transparent);
+  margin: 16px 0;
+  border: none;
+}
+.dark .gradient-divider {
+  background: linear-gradient(90deg, transparent, oklch(0.620 0.180 264 / 0.4), transparent);
+}
+
+/* Empty state container */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  border-radius: 16px;
+  border: 1px dashed oklch(0.488 0.180 264 / 0.3);
+  background: oklch(0.488 0.180 264 / 0.02);
+}
+.dark .empty-state {
+  border-color: oklch(0.620 0.180 264 / 0.3);
+  background: oklch(0.620 0.180 264 / 0.03);
+}
+
+/* Prominent new-chat button (sidebar) */
+.new-chat-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: oklch(1 0 0);
+  border: 1px solid oklch(0.915 0.008 260);
+  color: oklch(0.205 0.015 265);
+  font-size: 13px;
+  font-weight: 500;
+  transition: all 0.15s ease;
+  box-shadow: 0 1px 2px oklch(0.145 0.014 265 / 0.04);
+}
+.new-chat-btn:hover {
+  border-color: oklch(0.488 0.180 264 / 0.4);
+  background: oklch(0.998 0.002 260);
+  box-shadow: 0 2px 8px oklch(0.488 0.180 264 / 0.08);
+}
+.dark .new-chat-btn {
+  background: oklch(0.230 0.020 265);
+  border-color: oklch(0.280 0.018 265);
+  color: oklch(0.955 0.008 260);
+}
+.dark .new-chat-btn:hover {
+  background: oklch(0.260 0.025 265);
+  border-color: oklch(0.620 0.180 264 / 0.5);
+}
+
+
+/* Card hover glow effect */
+.card-hover-glow {
+  transition: box-shadow 0.25s ease, border-color 0.25s ease;
+}
+.card-hover-glow:hover {
+  box-shadow: 0 0 0 1px oklch(0.488 0.180 264 / 0.15), 0 4px 16px oklch(0.488 0.180 264 / 0.08);
+  border-color: oklch(0.488 0.180 264 / 0.3);
+}
+.dark .card-hover-glow:hover {
+  box-shadow: 0 0 0 1px oklch(0.620 0.180 264 / 0.2), 0 4px 20px oklch(0.620 0.180 264 / 0.1);
+  border-color: oklch(0.620 0.180 264 / 0.3);
+}
+
+/* Chunk card — left border accent */
+.chunk-card {
+  border-left: 3px solid oklch(0.488 0.180 264 / 0.4);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.chunk-card:hover {
+  border-left-color: oklch(0.488 0.180 264);
+  box-shadow: 0 2px 12px oklch(0.488 0.180 264 / 0.08);
+}
+.dark .chunk-card {
+  border-left-color: oklch(0.620 0.180 264 / 0.4);
+}
+.dark .chunk-card:hover {
+  border-left-color: oklch(0.620 0.180 264);
+  box-shadow: 0 2px 12px oklch(0.620 0.180 264 / 0.1);
+}
+
+/* Chat message — user (indigo gradient) */
+.msg-user {
+  background: linear-gradient(135deg, oklch(0.488 0.180 264), oklch(0.520 0.190 275));
+  color: white;
+}
+
+/* Chat message — assistant (transparent, no card) */
+.msg-assistant {
+  background: transparent;
+}
+
+/* Table row hover */
+.table-row-hover {
+  transition: background-color 0.15s ease;
+}
+.table-row-hover:hover {
+  background-color: oklch(0.488 0.180 264 / 0.04);
+}
+.dark .table-row-hover:hover {
+  background-color: oklch(0.620 0.180 264 / 0.06);
+}
+
+/* Badge tech style */
+.badge-tech {
+  background: oklch(0.488 0.180 264 / 0.1);
+  color: oklch(0.488 0.180 264);
+  border: 1px solid oklch(0.488 0.180 264 / 0.2);
+}
+.dark .badge-tech {
+  background: oklch(0.620 0.180 264 / 0.15);
+  color: oklch(0.620 0.180 264);
+  border-color: oklch(0.620 0.180 264 / 0.2);
+}
+
+/* ===== Markdown Content Styles ===== */
 .markdown-content {
   font-family: "Segoe UI", system-ui, sans-serif;
   line-height: 1.8;
-  color: #101317;
+  color: oklch(0.145 0.014 265);
+}
+
+.dark .markdown-content {
+  color: oklch(0.955 0.008 260);
 }
 
 .markdown-content h1,
 .markdown-content h2,
-.markdown-content h3 .markdown-content h4 .markdown-content h5 {
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5 {
   position: relative;
   padding-bottom: 0.3em;
   margin-top: 0.3em;
   margin-bottom: 0.3em;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid oklch(0.915 0.008 260);
   transition: all 0.3s ease;
+}
+
+.dark .markdown-content h1,
+.dark .markdown-content h2,
+.dark .markdown-content h3,
+.dark .markdown-content h4,
+.dark .markdown-content h5 {
+  border-bottom-color: oklch(0.280 0.018 265);
 }
 
 .markdown-content h1 {
   font-size: 2.2rem;
-  background: linear-gradient(120deg, #2c3e50, #34495e);
+  background: linear-gradient(120deg, oklch(0.488 0.180 264), oklch(0.560 0.200 280));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 
 .markdown-content h2 {
   font-size: 2rem;
-  color: #2d3748;
+  color: oklch(0.205 0.015 265);
 }
 
 .markdown-content h3 {
   font-size: 1.8rem;
-  color: #4a5568;
+  color: oklch(0.350 0.020 265);
 }
 
 .markdown-content h4 {
   font-size: 1.6rem;
-  color: #4a5568;
+  color: oklch(0.350 0.020 265);
 }
 
 .markdown-content h5 {
   font-size: 1.4rem;
-  color: #4a5568;
+  color: oklch(0.350 0.020 265);
+}
+
+.dark .markdown-content h2,
+.dark .markdown-content h3,
+.dark .markdown-content h4,
+.dark .markdown-content h5 {
+  color: oklch(0.800 0.012 260);
 }
 
 .markdown-content p {
@@ -182,18 +914,28 @@ html {
 .markdown-content code {
   padding: 0.2em 0.4em;
   border-radius: 6px;
-  background-color: #f7fafc;
-  color: #4299e1;
+  background-color: oklch(0.955 0.012 260);
+  color: oklch(0.488 0.180 264);
   font-weight: 500;
 }
 
+.dark .markdown-content code {
+  background-color: oklch(0.230 0.020 265);
+  color: oklch(0.620 0.180 264);
+}
+
 .markdown-content pre {
-  background-color: #0f172a;
-  color: #f1f5f9;
+  background-color: oklch(0.160 0.018 265);
+  color: oklch(0.920 0.008 260);
   padding: 1em;
   border-radius: 8px;
   overflow-x: auto;
   margin: 1.5em 0;
+}
+
+.markdown-content pre code {
+  background-color: transparent;
+  color: inherit;
 }
 
 .markdown-content ul,
@@ -203,16 +945,25 @@ html {
 }
 
 .markdown-content blockquote {
-  border-left: 4px solid #3b82f6;
-  color: #475569;
+  border-left: 4px solid oklch(0.488 0.180 264);
+  color: oklch(0.450 0.020 265);
   margin: 1.5em 0;
   padding-left: 1em;
 }
 
+.dark .markdown-content blockquote {
+  border-left-color: oklch(0.620 0.180 264);
+  color: oklch(0.700 0.015 265);
+}
+
 .markdown-content a {
-  color: #3b82f6;
+  color: oklch(0.488 0.180 264);
   text-decoration: none;
   position: relative;
+}
+
+.dark .markdown-content a {
+  color: oklch(0.620 0.180 264);
 }
 
 .markdown-content a:hover::after {
@@ -222,5 +973,9 @@ html {
   right: 0;
   bottom: -2px;
   height: 2px;
-  background-color: #3b82f6;
+  background-color: oklch(0.488 0.180 264);
+}
+
+.dark .markdown-content a:hover::after {
+  background-color: oklch(0.620 0.180 264);
 }

--- a/frontend/app/knowledgebases/[kbId]/files/[fileId]/page.tsx
+++ b/frontend/app/knowledgebases/[kbId]/files/[fileId]/page.tsx
@@ -415,7 +415,7 @@ export default function KnowledgeBaseFileChunksPage(
             <div className="gap-1 px-3 py-0 w-full">
               <div className="grid grid-cols-4 items-center gap-2">
                 {kbfilechunks.map((chunk) => (
-                  <Card key={chunk.id} className="h-70 px-0 pt-3 pb-1 gap-2 group relative">
+                  <Card key={chunk.id} className="h-70 px-0 pt-3 pb-1 gap-2 group relative chunk-card">
                     <CardHeader>
                       <CardTitle className="flex justify-between items-start">
                         <div className="flex items-center gap-2">

--- a/frontend/app/knowledgebases/page.tsx
+++ b/frontend/app/knowledgebases/page.tsx
@@ -116,7 +116,7 @@ export default function KnowledgeBasePage() {
   return (
     <div className="flex flex-col h-screen px-6 py-0 space-y-4">
       <div className="flex justify-between items-center h-1/10 gap-4">
-        <h1 className="text-xl font-medium">{t('knowledgebase.title')}</h1>
+        <h1 className="page-title">{t('knowledgebase.title')}</h1>
         <div className="flex items-center gap-3 flex-1 max-w-md">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
@@ -157,7 +157,7 @@ export default function KnowledgeBasePage() {
                     router.push(`/knowledgebases/${base.id}`);
                   }}
                   key={base.id}
-                  className="group flex flex-col border rounded-lg shadow-sm h-full gap-0 py-0 transition-shadow hover:shadow-md hover:bg-muted/50 duration-300 relative"
+                  className="group flex flex-col border rounded-lg shadow-sm h-full gap-0 py-0 card-hover-glow duration-300 relative"
                 >
                   {/* 右上角：删除按钮（hover时显示） */}
                   <div className="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
@@ -211,7 +211,7 @@ export default function KnowledgeBasePage() {
                     {/* 文档数量 Badge */}
                     <Badge 
                       variant="outline" 
-                      className="text-xs bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20 dark:border-blue-400/30"
+                      className="text-xs badge-tech"
                     >
                       <FileText className="w-3 h-3" />
                       {base.file_count || 0}
@@ -220,7 +220,7 @@ export default function KnowledgeBasePage() {
                     {/* 更新时间 Badge */}
                     <Badge 
                       variant="outline" 
-                      className="text-xs bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20 dark:border-blue-400/30"
+                      className="text-xs badge-tech"
                     >
                       {formatFriendlyTime(base.updated_at)}
                     </Badge>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
                 <MyChatRuntimeProvider>
                   <SidebarProvider>
                     <AppSidebar />
-                    <SidebarInset>
+                    <SidebarInset className="main-gradient-bg">
                       <div className="h-screen w-full overflow-hidden flex flex-col">
                         <header className="flex items-center justify-between shrink-0 w-full px-2 pt-3 pb-1">
                           <SidebarTrigger className="w-10" />

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -72,14 +72,11 @@ export function AppSidebar() {
   return (
     <Sidebar side="left">
       <SidebarHeader>
-        <div className="flex items-center space-x-2">
-          <Avatar>
-            <AvatarImage
-              src="https://pai-rag.oss-cn-hangzhou.aliyuncs.com/logo/pairag_1.png"
-              alt="@shadcn"
-            />
-          </Avatar>
-          <span className="text-lg font-medium">PAI-RAG</span>
+        <div className="flex items-center gap-2.5 px-1 py-1">
+          <div className="logo-icon flex items-center justify-center w-8 h-8 rounded-lg font-bold text-sm shrink-0">
+            P
+          </div>
+          <span className="text-base font-semibold tracking-tight">PAI-RAG</span>
         </div>
         {/* 工作空间选择器 */}
         <div className="mt-1">

--- a/frontend/components/assistant-ui/thread-list.tsx
+++ b/frontend/components/assistant-ui/thread-list.tsx
@@ -24,14 +24,19 @@ const ThreadListNew: FC = () => {
   const router = useRouter();
   return (
     <ThreadListPrimitive.New asChild>
-      <Button
-        className="data-[active]:bg-muted hover:bg-muted flex items-center justify-start gap-1 rounded-lg px-2.5 py-2 text-start"
-        variant="ghost"
+      <button
+        className="new-chat-btn mb-1"
         onClick={() => {router.push('/')}}
       >
-        <PlusIcon />
-        <span suppressHydrationWarning>{t('chat.threadList.newConversation')}</span>
-      </Button>
+        <span className="flex items-center gap-2">
+          <PlusIcon className="w-4 h-4" />
+          <span suppressHydrationWarning>{t('chat.threadList.newConversation')}</span>
+        </span>
+        <span className="flex items-center gap-0.5">
+          <span className="kbd-badge">⌘</span>
+          <span className="kbd-badge">P</span>
+        </span>
+      </button>
     </ThreadListPrimitive.New>
   );
 };

--- a/frontend/components/assistant-ui/thread.tsx
+++ b/frontend/components/assistant-ui/thread.tsx
@@ -231,7 +231,7 @@ export const Thread: FC<{
   return (
     <>
       <ThreadPrimitive.Root
-        className="bg-background box-border flex h-full flex-col overflow-hidden"
+        className="box-border flex h-full flex-col overflow-hidden"
         style={{
           ['--thread-max-width' as string]: '60rem',
         }}
@@ -312,7 +312,12 @@ const ThreadWelcome: FC = () => {
     <ThreadPrimitive.Empty>
       <div className="flex w-full max-w-[var(--thread-max-width)] flex-grow flex-col">
         <div className="flex w-full flex-grow flex-col items-center justify-center">
-          <p className="mt-4 font-medium">{t('chat.thread.welcomeMessage')}</p>
+          <h2 className="text-3xl font-semibold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text">
+            {t('chat.thread.welcomeMessage')}
+          </h2>
+          <p className="mt-3 text-sm text-muted-foreground">
+            提问、上传文档进行知识分析，或交由我规划并执行任务
+          </p>
         </div>
         <ThreadWelcomeSuggestions />
       </div>
@@ -323,24 +328,26 @@ const ThreadWelcome: FC = () => {
 const ThreadWelcomeSuggestions: FC = () => {
   const { t } = useI18n();
   return (
-    <div className="mt-3 flex w-full items-stretch justify-center gap-4 pb-8">
+    <div className="mt-6 flex w-full items-stretch justify-center gap-3 pb-8 flex-wrap">
       <ThreadPrimitive.Suggestion
-        className="hover:bg-muted/80 flex max-w-sm grow basis-0 flex-col items-center justify-center rounded-lg border p-3 transition-colors ease-in"
+        className="suggest-pill cursor-pointer max-w-sm"
         prompt={t('chat.thread.suggestion1')}
         method="replace"
         autoSend
       >
-        <span className="line-clamp-2 text-gray-800 text-xs text-ellipsis text-sm font-semibold">
+        <Brain className="w-4 h-4 text-primary shrink-0" />
+        <span className="line-clamp-1">
           {t('chat.thread.suggestion1')}
         </span>
       </ThreadPrimitive.Suggestion>
       <ThreadPrimitive.Suggestion
-        className="hover:bg-muted/80 flex max-w-sm grow basis-0 flex-col items-center justify-center rounded-lg border p-3 transition-colors ease-in"
+        className="suggest-pill cursor-pointer max-w-sm"
         prompt={t('chat.thread.suggestion2')}
         method="replace"
         autoSend
       >
-        <span className="line-clamp-2 text-gray-800 text-xs text-ellipsis text-sm font-semibold">
+        <Search className="w-4 h-4 text-primary shrink-0" />
+        <span className="line-clamp-1">
           {t('chat.thread.suggestion2')}
         </span>
       </ThreadPrimitive.Suggestion>
@@ -366,8 +373,7 @@ const Composer: FC<ComposerProps> = ({
   const { t } = useI18n();
   return (
     <ComposerPrimitive.Root
-      // className="focus-within:border-ring/20 flex w-full flex-wrap items-end rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in"
-      className="focus-within:border-ring/20 flex w-full flex-col rounded-lg border bg-inherit px-2.5 shadow-sm transition-colors ease-in"
+      className="composer-box flex w-full flex-col px-3"
     >
       {/* First row: input box */}
       <div className="flex items-center justify-between px-2 pb-1">
@@ -395,14 +401,14 @@ const Composer: FC<ComposerProps> = ({
                   <ToggleGroupItem
                     value="search"
                     aria-label="Toggle web search"
-                    className="!rounded-full px-2 py-1 data-[state=on]:bg-black data-[state=on]:text-white h-8"
+                    className="!rounded-full px-2 py-1 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-8"
                   >
                     <Search /> {t('chat.thread.search')}
                   </ToggleGroupItem>
                   <ToggleGroupItem
                     value="mcp"
                     aria-label="Toggle mcp"
-                    className="!rounded-full px-2 py-1 data-[state=on]:bg-black data-[state=on]:text-white h-8"
+                    className="!rounded-full px-2 py-1 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-8"
                     onClick={() => {
                       onOpenMcpModal?.();
                     }}
@@ -412,7 +418,7 @@ const Composer: FC<ComposerProps> = ({
                   <ToggleGroupItem
                     value="kb"
                     aria-label="Toggle kb"
-                    className="!rounded-full px-2 py-1 data-[state=on]:bg-black data-[state=on]:text-white h-8"
+                    className="!rounded-full px-2 py-1 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-8"
                     onClick={() => {
                       onOpenKbModal?.();
                     }}
@@ -422,7 +428,7 @@ const Composer: FC<ComposerProps> = ({
                   <ToggleGroupItem
                     value="chatdb"
                     aria-label="Toggle chatdb"
-                    className="!rounded-full px-6 py-1 data-[state=on]:bg-black data-[state=on]:text-white h-8"
+                    className="!rounded-full px-6 py-1 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-8"
                   >
                     <DatabaseIcon /> ChatDB
                   </ToggleGroupItem>
@@ -446,24 +452,24 @@ const ComposerAction: FC = () => {
     <>
       <ThreadPrimitive.If running={false}>
         <ComposerPrimitive.Send asChild>
-          <TooltipIconButton
-            tooltip={t('chat.thread.send')}
-            variant="default"
-            className="my-2.5 w-18 h-10 p-2 transition-opacity ease-in"
+          <button
+            aria-label={t('chat.thread.send')}
+            title={t('chat.thread.send')}
+            className="send-btn-circle my-2"
           >
-            <SendHorizontalIcon />
-          </TooltipIconButton>
+            <SendHorizontalIcon className="w-4 h-4" />
+          </button>
         </ComposerPrimitive.Send>
       </ThreadPrimitive.If>
       <ThreadPrimitive.If running>
         <ComposerPrimitive.Cancel asChild>
-          <TooltipIconButton
-            tooltip={t('chat.thread.cancel')}
-            variant="default"
-            className="my-2.5 w-18 h-10 p-2 transition-opacity ease-in"
+          <button
+            aria-label={t('chat.thread.cancel')}
+            title={t('chat.thread.cancel')}
+            className="send-btn-circle my-2"
           >
             <CircleStopIcon />
-          </TooltipIconButton>
+          </button>
         </ComposerPrimitive.Cancel>
       </ThreadPrimitive.If>
     </>
@@ -474,7 +480,7 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root className="grid auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 [&:where(>*)]:col-start-2 w-full max-w-[var(--thread-max-width)] py-4">
       <UserActionBar />
-      <div className="bg-muted text-foreground max-w-[calc(var(--thread-max-width)*0.8)] break-words rounded-2xl px-5 py-2 col-start-2 row-start-2 text-sm">
+      <div className="msg-user max-w-[calc(var(--thread-max-width)*0.8)] break-words rounded-2xl px-5 py-2 col-start-2 row-start-2 text-sm">
         <UserMessageAttachments />
         <MessagePrimitive.Content />
       </div>


### PR DESCRIPTION
## Summary

Replace the default shadcn zinc theme with a cohesive **indigo-blue tech palette** tailored for a knowledge base + Agent Q&A product. The goal is a cleaner, more distinctive visual identity across chat, knowledge bases, and all settings pages.

## What changed

### Theme foundation (`globals.css`)
- New OKLCH indigo palette in `:root` and `.dark`, refined sidebar colors, gradient main-content background
- Markdown content rules now follow theme variables (was hardcoded hex)
- Introduced a set of reusable utility classes:
  - Layout: `settings-page`, `settings-page-header`, `settings-page-content`, `section-panel`, `section-header`
  - Typography: `page-title`, `section-title`, `dialog-section-title`
  - Cards: `card-hover-glow`, `chunk-card`, `model-card`, `model-icon` (+ `type-llm`/`type-embedding`/`type-reranker` variants), `type-corner-badge`
  - Forms: `form-label`, `form-row-inline`, `composer-box`, `send-btn-circle`, `endpoint-text`
  - Badges: `badge-tech`, `badge-success`, `badge-warning`, `badge-danger`, `badge-neutral`
  - Misc: `menu-compact`, `tabs-modern`, `table-modern`, `suggest-pill`, `new-chat-btn`, `kbd-badge`, `logo-icon`

### Chat experience
- Purple-indigo "P" logo mark (replaces external avatar image)
- Compact new-chat button with `⌘ P` keyboard-shortcut badge
- Larger welcome heading with subtitle and pill-style suggestion chips
- Composer with rounded focus-glow and circular blue send button
- User messages get an indigo gradient bubble; assistant messages render flat
- Tool toggle pills use primary color when active

### Model config (`/config/model`)
- Combined LLM / Embedding / Reranker into a single scrollable page (no more tabs, no pagination — fetches up to 100)
- Each type has its own `section-panel` with header, count, and `+ Add` button
- Compact model cards: type-coded icon, top-right `LLM`/`EMB`/`RNK` corner badge, three-dot dropdown for Edit/Delete
- Removed redundant Active toggle on LLM cards
- Dialogs rebuilt with top-aligned `form-label`s, Basic/Endpoint/Advanced groupings, `form-row-inline` for switches/temperature, type-specific titles + Cancel button
- Embedding type selector is now a segmented control, hides Endpoint/API Key for `local`

### Settings pages
All settings pages converted to the unified `settings-page` layout (centered max-width, page title with right-aligned action buttons, section groupings):
- **search** — engine selector + Aliyun/Tavily credentials + slider for result count
- **code_sandbox** — enable switch + sandbox type + Aliyun FC credentials + timeout slider
- **chatdb** — model picker + DB connection grid (Test Connection + Save in header)
- **tracing** — OpenTelemetry endpoint/token/service + enable switch
- **guardrail** — region selector + Aliyun AK/SK
- **cache** — metadata schema cache row with destructive Clear button
- **vectordb** — DB type selector + per-type form (no card wrapper)
- **mcp** — table list with row-level dropdown (Edit/Delete) and Switch toggle; modernized Add/Edit dialogs

### Bug fixes
- Fixed Radix `DropdownMenu` + `Dialog` interaction where the body's `pointer-events: none` was left behind after closing — set `modal={false}` on `DropdownMenu` and use `onSelect` for menu items
- Fixed dialog title flicker between "添加" and "编辑" during the close animation by freezing `isAdd` in a local `displayIsAdd` state
- Fixed model cards' Edit button leaving the three-dot menu unclickable

## Test plan

- [ ] Run `npm run build` in `frontend/` (passes)
- [ ] Visit `/` — chat layout has light sidebar, gradient bg, gradient user bubbles, circular send button
- [ ] Visit `/knowledgebases`, `/apps` — cards have subtle indigo hover glow, blue tech-style badges
- [ ] Visit `/config/model` — single page with three sections, type-coded cards, three-dot menu opens Edit dialog smoothly
- [ ] Add/edit each of LLM, Embedding, Reranker — dialog title shows correct type, no flicker on close
- [ ] Visit each `/config/*` page — header (title + action button) and content centered at the same width
- [ ] Toggle Light/Dark mode — colors remain readable