### PR TITLE
Fix dropdown freeze bug + unify ConfirmDialog and loading primitives

### DIFF
--- a/frontend/app/apps/[appId]/page.tsx
+++ b/frontend/app/apps/[appId]/page.tsx
@@ -5,6 +5,7 @@ import { FAQManagement } from "../faq_management";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { HeaderPortal } from "@/components/header-portal";
+import { PageLoading } from "@/components/ui/loading";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -147,7 +148,7 @@ export default function ViewChatApp(
 
     // Navigate back after save
     if (loading) {
-        return <div className="flex items-center justify-center h-screen">{t('common.loading')}</div>;
+        return <PageLoading className="h-full" />;
     }
 
     return (

--- a/frontend/app/apps/create/page.tsx
+++ b/frontend/app/apps/create/page.tsx
@@ -19,6 +19,7 @@ import {
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
 import { HeaderPortal } from "@/components/header-portal";
+import { PageLoading } from "@/components/ui/loading";
 
 
 
@@ -119,7 +120,7 @@ const default_chat_config: Chatbot = {
     }, [botConfig, tenantFetch, router]);
 
     if (loading) {
-        return <div className="flex items-center justify-center h-screen">{t('common.loading')}</div>;
+        return <PageLoading className="h-full" />;
     }
 
     return (

--- a/frontend/app/apps/faq_management.tsx
+++ b/frontend/app/apps/faq_management.tsx
@@ -34,6 +34,8 @@ import { Slider } from '@/components/ui/slider';
 import { Plus, Edit, Trash2, Settings, HelpCircle, Upload, MessageSquareQuote, FileQuestion, ChevronDown } from 'lucide-react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Section } from './chatbot_config';
+import { PageLoading } from '@/components/ui/loading';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { toast } from 'sonner';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { Switch } from '@/components/ui/switch';
@@ -85,6 +87,8 @@ export const FAQManagement: React.FC<FAQManagementProps> = ({ appId, botConfig, 
   const [isConfigDialogOpen, setIsConfigDialogOpen] = useState(false);
   const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false);
   const [isListExpanded, setIsListExpanded] = useState(false);
+  const [deleteFaqTarget, setDeleteFaqTarget] = useState<FAQItem | null>(null);
+  const [showBatchDeleteConfirm, setShowBatchDeleteConfirm] = useState(false);
   const [uploadFiles, setUploadFiles] = useState<File[]>([]);
   const [uploadConfig, setUploadConfig] = useState<{
     header_index_max: number | null;
@@ -258,25 +262,28 @@ export const FAQManagement: React.FC<FAQManagementProps> = ({ appId, botConfig, 
     }
   };
 
-  const handleDelete = async (faqId: string) => {
-    if (!confirm(t('apps.faqConfirmDeleteOne'))) return;
+  const handleDelete = (faq: FAQItem) => {
+    // Open the unified confirm dialog instead of native confirm()
+    setDeleteFaqTarget(faq);
+  };
 
+  const performDelete = async (faqId: string) => {
     try {
       const res = await tenantFetch(`/api/config/apps/${appId}/faqs/${faqId}`, {
         method: 'DELETE',
       });
 
       if (!res.ok) throw new Error(t('apps.deleteError'));
-      
+
       toast.success(t('messages.deleteSuccess'));
-      
+
       // 从选中项中移除
-      setSelectedItems(prev => {
+      setSelectedItems((prev) => {
         const newSet = new Set(prev);
         newSet.delete(faqId);
         return newSet;
       });
-      
+
       // 如果当前页只有一条数据，删除后应该跳转到上一页
       if (faqs.length === 1 && page > 1) {
         setPage(page - 1);
@@ -285,6 +292,8 @@ export const FAQManagement: React.FC<FAQManagementProps> = ({ appId, botConfig, 
       }
     } catch (error: any) {
       toast.error(error.message || t('apps.deleteError'));
+    } finally {
+      setDeleteFaqTarget(null);
     }
   };
 
@@ -321,14 +330,15 @@ export const FAQManagement: React.FC<FAQManagementProps> = ({ appId, botConfig, 
     }
   };
 
-  const handleBatchDelete = async () => {
+  const handleBatchDelete = () => {
     if (selectedItems.size === 0) {
       toast.error(t('apps.faqSelectToDelete'));
       return;
     }
+    setShowBatchDeleteConfirm(true);
+  };
 
-    if (!confirm(t('apps.faqConfirmDeleteSelected', { count: String(selectedItems.size) }))) return;
-
+  const performBatchDelete = async () => {
     try {
       const deletePromises = Array.from(selectedItems).map(faqId =>
         tenantFetch(`/api/config/apps/${appId}/faqs/${faqId}`, {
@@ -348,11 +358,13 @@ export const FAQManagement: React.FC<FAQManagementProps> = ({ appId, botConfig, 
 
       // 清空选中项
       setSelectedItems(new Set());
-      
+
       // 刷新列表
       fetchFAQs();
     } catch (error: any) {
       toast.error(error.message || t('apps.faqBatchDeleteFailed'));
+    } finally {
+      setShowBatchDeleteConfirm(false);
     }
   };
 
@@ -528,7 +540,7 @@ export const FAQManagement: React.FC<FAQManagementProps> = ({ appId, botConfig, 
             </div>
             <CollapsibleContent className="mt-4">
           {loading ? (
-            <div className="text-center py-8 text-muted-foreground">{t('common.loading')}</div>
+            <PageLoading />
           ) : faqs.length === 0 ? (
             <div className="empty-state">
               <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-4">
@@ -586,7 +598,7 @@ export const FAQManagement: React.FC<FAQManagementProps> = ({ appId, botConfig, 
                               variant="ghost"
                               size="icon"
                               className="h-8 w-8 hover:text-destructive"
-                              onClick={() => faq.id && handleDelete(faq.id)}
+                              onClick={() => faq.id && handleDelete(faq)}
                             >
                               <Trash2 className="w-4 h-4" />
                             </Button>
@@ -1034,6 +1046,25 @@ export const FAQManagement: React.FC<FAQManagementProps> = ({ appId, botConfig, 
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Single FAQ delete confirmation */}
+      <ConfirmDialog
+        open={!!deleteFaqTarget}
+        onOpenChange={(o) => !o && setDeleteFaqTarget(null)}
+        title={t('apps.faqConfirmDeleteOne')}
+        target={deleteFaqTarget ? { value: deleteFaqTarget.question } : undefined}
+        onConfirm={() => {
+          if (deleteFaqTarget?.id) performDelete(deleteFaqTarget.id);
+        }}
+      />
+
+      {/* Batch FAQ delete confirmation */}
+      <ConfirmDialog
+        open={showBatchDeleteConfirm}
+        onOpenChange={setShowBatchDeleteConfirm}
+        title={t('apps.faqConfirmDeleteSelected', { count: String(selectedItems.size) })}
+        onConfirm={performBatchDelete}
+      />
     </div>
   );
 };

--- a/frontend/app/apps/page.tsx
+++ b/frontend/app/apps/page.tsx
@@ -9,16 +9,7 @@ import {
 import { Plus, Trash2, MoreHorizontal, Pencil, Clock, AppWindow } from 'lucide-react';
 import { PaginationComponent } from '@/components/customized/pagination/pagination-component';
 import { formatBeijingTime } from '../knowledgebases/utils/utils';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,6 +22,7 @@ import { useRouter } from 'next/navigation';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 import { HeaderPortal } from '@/components/header-portal';
+import { PageLoading } from '@/components/ui/loading';
 
 const ChatbotPage = () => {
   const { t } = useI18n();
@@ -110,9 +102,7 @@ const ChatbotPage = () => {
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="max-w-7xl mx-auto px-6 py-5">
           {loading ? (
-            <div className="text-center py-16 text-sm text-muted-foreground">
-              {t('common.loading')}
-            </div>
+            <PageLoading />
           ) : chatbots.length === 0 ? (
             <div className="empty-state mt-8">
               <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-4">
@@ -156,7 +146,11 @@ const ChatbotPage = () => {
                           ID · {bot.id.slice(0, 8)}
                         </p>
                       </div>
-                      <div data-stop-click className="opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div
+                        data-stop-click
+                        className="opacity-0 group-hover:opacity-100 transition-opacity"
+                        onClick={(e) => e.stopPropagation()}
+                      >
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <Button
@@ -178,7 +172,11 @@ const ChatbotPage = () => {
                             <DropdownMenuItem
                               onSelect={(e) => {
                                 e.preventDefault();
-                                setDeleteTarget(bot);
+                                // Defer opening the dialog so DropdownMenu
+                                // finishes its close/focus cleanup first —
+                                // otherwise Radix leaves body.style.pointerEvents
+                                // stuck at 'none' and the page freezes.
+                                setTimeout(() => setDeleteTarget(bot), 0);
                               }}
                               className="text-destructive focus:text-destructive"
                             >
@@ -221,33 +219,16 @@ const ChatbotPage = () => {
       )}
 
       {/* Delete confirmation */}
-      <AlertDialog
+      <ConfirmDialog
         open={!!deleteTarget}
-        onOpenChange={(open) => !open && setDeleteTarget(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('apps.deleteConfirmTitle')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('apps.deleteConfirmMessage')}
-              {deleteTarget && (
-                <span className="block mt-2 font-medium text-foreground">
-                  {deleteTarget.app_id}
-                </span>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => deleteTarget && deleteChatbot(deleteTarget.id)}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {t('common.delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        title={t('apps.deleteConfirmTitle')}
+        description={t('apps.deleteConfirmMessage')}
+        target={deleteTarget ? { label: 'App', value: deleteTarget.app_id } : undefined}
+        onConfirm={() => {
+          if (deleteTarget) deleteChatbot(deleteTarget.id);
+        }}
+      />
     </div>
   );
 };

--- a/frontend/app/config/mcp/mcpmodal.tsx
+++ b/frontend/app/config/mcp/mcpmodal.tsx
@@ -13,7 +13,8 @@ import type { FC } from 'react';
 import { useState, useEffect } from 'react';
 import { useChatOptions } from '@/app/providers/chat';
 import { useI18n } from '@/app/providers/i18n';
-import { PlugZap, Check, Loader2 } from 'lucide-react';
+import { PlugZap, Check } from 'lucide-react';
+import { Loading } from '@/components/ui/loading';
 
 export class McpEntry extends McpConfig {
   active: boolean = false;
@@ -87,9 +88,8 @@ export const McpModal: FC<McpModalProps> = ({
 
         <div className="max-h-[360px] overflow-y-auto p-2 space-y-0.5">
           {isLoading ? (
-            <div className="flex items-center justify-center gap-2 py-8 text-xs text-muted-foreground">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {t('common.loading')}
+            <div className="flex items-center justify-center py-8">
+              <Loading size="sm" />
             </div>
           ) : error ? (
             <p className="text-xs text-destructive text-center py-6">{error}</p>

--- a/frontend/app/config/mcp/page.tsx
+++ b/frontend/app/config/mcp/page.tsx
@@ -255,13 +255,21 @@ export default function McpConfigPage() {
                         </button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="menu-compact">
-                        <DropdownMenuItem onSelect={() => handleEditClick(config)}>
+                        <DropdownMenuItem
+                          onSelect={(e) => {
+                            e.preventDefault();
+                            setTimeout(() => handleEditClick(config), 0);
+                          }}
+                        >
                           <Edit />
                           {t('common.edit') || 'Edit'}
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           className="text-destructive focus:text-destructive"
-                          onSelect={() => removeMCP(config.id)}
+                          onSelect={(e) => {
+                            e.preventDefault();
+                            setTimeout(() => removeMCP(config.id), 0);
+                          }}
                         >
                           <TrashIcon />
                           {t('common.delete') || 'Delete'}

--- a/frontend/app/config/model/embedding/modelDialog.tsx
+++ b/frontend/app/config/model/embedding/modelDialog.tsx
@@ -13,16 +13,7 @@ import { Input } from '@/components/ui/input';
 import { Alert, AlertTitle } from '@/components/ui/alert';
 import { AlertCircleIcon } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 import { cn } from '@/lib/utils';
@@ -313,31 +304,22 @@ export const EmbeddingModelDialog: FC<EmbeddingModelDialogProps> = ({
         </div>
 
         {/* Confirm default change */}
-        <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>
-                {t('config.model.confirmChangeDefaultModel')}
-              </AlertDialogTitle>
-              <AlertDialogDescription>
-                {pendingState
-                  ? t('config.model.setAsDefaultWarning')
-                  : t('config.model.unsetAsDefaultWarning')}
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={() => {
-                  setEmb({ ...emb, is_default: pendingState || false });
-                  setIsDialogOpen(false);
-                }}
-              >
-                {t('config.model.confirmChange')}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <ConfirmDialog
+          open={isDialogOpen}
+          onOpenChange={setIsDialogOpen}
+          variant="warning"
+          title={t('config.model.confirmChangeDefaultModel')}
+          description={
+            pendingState
+              ? t('config.model.setAsDefaultWarning')
+              : t('config.model.unsetAsDefaultWarning')
+          }
+          confirmLabel={t('config.model.confirmChange')}
+          onConfirm={() => {
+            setEmb({ ...emb, is_default: pendingState || false });
+            setIsDialogOpen(false);
+          }}
+        />
 
         <DialogFooter>
           <Button variant="outline" onClick={() => setIsOpen(false)}>

--- a/frontend/app/config/model/embedding/page.tsx
+++ b/frontend/app/config/model/embedding/page.tsx
@@ -5,12 +5,12 @@ import {
   TrashIcon,
   Edit,
   AlertCircleIcon,
-  Loader2,
   CheckCircle,
   Plus,
   Layers,
   MoreHorizontal,
 } from 'lucide-react';
+import { Spinner } from '@/components/ui/loading';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { EmbeddingModelDialog, EmbConfig } from '@/app/config/model/embedding/modelDialog';
@@ -192,7 +192,7 @@ export default function EmbConfigPage() {
                     ) : (
                       <span className="inline-flex items-center gap-1">
                         {t('config.model.downloading')}
-                        <Loader2 className="h-3 w-3 animate-spin" />
+                        <Spinner size="sm" />
                       </span>
                     )}
                   </Badge>

--- a/frontend/app/config/model/llm/page.tsx
+++ b/frontend/app/config/model/llm/page.tsx
@@ -148,9 +148,12 @@ export default function LlmConfigPage() {
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="menu-compact">
                     <DropdownMenuItem
-                      onSelect={() => {
-                        setEditLlmConfig(llm);
-                        setIsEditOpen(true);
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        setTimeout(() => {
+                          setEditLlmConfig(llm);
+                          setIsEditOpen(true);
+                        }, 0);
                       }}
                     >
                       <Edit />
@@ -158,7 +161,10 @@ export default function LlmConfigPage() {
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       className="text-destructive focus:text-destructive"
-                      onSelect={() => removeModel(llm.id)}
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        setTimeout(() => removeModel(llm.id), 0);
+                      }}
                     >
                       <TrashIcon />
                       {t('common.delete') || 'Delete'}

--- a/frontend/app/config/model/reranker/page.tsx
+++ b/frontend/app/config/model/reranker/page.tsx
@@ -145,9 +145,12 @@ export default function RerankerConfigPage() {
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="menu-compact">
                     <DropdownMenuItem
-                      onSelect={() => {
-                        setEditRerankerConfig(reranker);
-                        setIsEditOpen(true);
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        setTimeout(() => {
+                          setEditRerankerConfig(reranker);
+                          setIsEditOpen(true);
+                        }, 0);
                       }}
                     >
                       <Edit />
@@ -155,7 +158,10 @@ export default function RerankerConfigPage() {
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       className="text-destructive focus:text-destructive"
-                      onSelect={() => removeModel(reranker.id)}
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        setTimeout(() => removeModel(reranker.id), 0);
+                      }}
                     >
                       <TrashIcon />
                       {t('common.delete') || 'Delete'}

--- a/frontend/app/config/role/role.tsx
+++ b/frontend/app/config/role/role.tsx
@@ -5,7 +5,6 @@ import {
   TrashIcon,
   Edit,
   AlertCircleIcon,
-  Loader2,
   CheckCircle,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';

--- a/frontend/app/config/vectordb/page.tsx
+++ b/frontend/app/config/vectordb/page.tsx
@@ -16,8 +16,8 @@ import { HologresConfig, HologresForm } from "./forms/hologres";
 import { OpensearchConfig, OpensearchForm } from "./forms/opensearch";
 import { TablestoreConfig, TablestoreForm } from "./forms/tablestore";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
-import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/loading";
+import { PageLoading } from "@/components/ui/loading";
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
@@ -163,7 +163,7 @@ export default function VectorDBConsole() {
           <Button size="sm" variant="outline" onClick={testConnection} disabled={connectionTesting}>
             {connectionTesting ? (
               <>
-                <Loader2 className="w-4 h-4 animate-spin" />
+                <Spinner size="sm" className="mr-1" />
                 {t('config.vectordb.testing')}
               </>
             ) : (
@@ -178,7 +178,7 @@ export default function VectorDBConsole() {
 
       <div className="settings-page-content">
         {loading ? (
-          <Skeleton className="h-12 w-12 rounded-full" />
+          <PageLoading />
         ) : (
           <div className="space-y-6">
             <div>

--- a/frontend/app/evaluation/[datasetId]/evalconfigs/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/evalconfigs/page.tsx
@@ -27,9 +27,9 @@ import {
   Pencil,
   Trash2,
   ClipboardCheck,
-  Loader2,
   MoreHorizontal,
 } from 'lucide-react';
+import { PageLoading } from '@/components/ui/loading';
 import { EvalConfigFormDialog } from '@/app/evaluation/components/evalconfig-form-dialog';
 import { EvaluatorConfig } from '@/app/evaluation/[datasetId]/types';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
@@ -186,10 +186,7 @@ export default function EvaluatorConfigsPage({
         </div>
 
         {isLoading ? (
-          <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {t('evaluation.loadingConfigs')}
-          </div>
+          <PageLoading label={t('evaluation.loadingConfigs')} />
         ) : evaluatorConfigs.length === 0 ? (
           <div className="empty-state mt-4">
             <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-4">

--- a/frontend/app/evaluation/[datasetId]/experiments/[expId]/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/experiments/[expId]/page.tsx
@@ -51,7 +51,6 @@ import {
   TrendingDown,
   TrendingUp,
   XCircle,
-  Loader2
 } from "lucide-react";
 import { Fragment } from "react";
 import { PaginationComponent } from "@/components/customized/pagination/pagination-component";
@@ -95,6 +94,7 @@ import { SampleDetailDialog } from '@/app/evaluation/components/sample-detail-di
 import { SampleItem } from '@/app/evaluation/[datasetId]/types';
 import { useTenantFetch } from "@/hooks/use-tenant-fetch";
 import { HeaderPortal } from '@/components/header-portal';
+import { PageLoading } from '@/components/ui/loading';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -387,19 +387,7 @@ export default function ExperimentDetailPage({ params }: { params: Promise<{ dat
   // ========================
 
   if (!experiment) {
-    return (
-      <div className="container mx-auto p-6">
-        <Card>
-          <CardContent className="p-6 justify-center">
-            <div className="flex items-center space-x-2">
-              <Loader2 className="h-8 w-8 animate-spin" />
-              <h2 className="text-xl font-medium">{t('evaluation.loadingExperiment')}</h2>
-            </div>
-            <p className="text-gray-500 mt-2">{t('evaluation.loadingExperimentDesc')}</p>
-          </CardContent>
-        </Card>
-      </div>
-    );
+    return <PageLoading className="h-full" label={t('evaluation.loadingExperiment')} />;
   }
 
   const statusLabel = (value: string | null) => {
@@ -790,7 +778,11 @@ export default function ExperimentDetailPage({ params }: { params: Promise<{ dat
                             )}
                           </Button>
                         </TableCell>
-                        <TableCell className="px-2 py-0.5" data-stop-click>
+                        <TableCell
+                          className="px-2 py-0.5"
+                          data-stop-click
+                          onClick={(e) => e.stopPropagation()}
+                        >
                           <button
                             type="button"
                             className="text-xs font-mono text-primary hover:underline"
@@ -835,7 +827,11 @@ export default function ExperimentDetailPage({ params }: { params: Promise<{ dat
                             ? calculateTimeDifference(sample.started_at, sample.updated_at)
                             : '-'}
                         </TableCell>
-                        <TableCell className="text-right pr-3 px-2 py-0.5" data-stop-click>
+                        <TableCell
+                          className="text-right pr-3 px-2 py-0.5"
+                          data-stop-click
+                          onClick={(e) => e.stopPropagation()}
+                        >
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <Button

--- a/frontend/app/evaluation/[datasetId]/experiments/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/experiments/page.tsx
@@ -21,10 +21,10 @@ import {
   BookOpen,
   BarChart2,
   Trash2,
-  Loader2,
   Clock,
   CheckCircle2,
 } from 'lucide-react';
+import { PageLoading } from '@/components/ui/loading';
 import { Badge } from '@/components/ui/badge';
 import {
   DropdownMenu,
@@ -81,10 +81,7 @@ export default function EvalExperimentsDetailsPage({
     <div className="flex flex-col h-full min-h-0">
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-3">
         {isLoading ? (
-          <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {t('evaluation.loadingExperiments')}
-          </div>
+          <PageLoading label={t('evaluation.loadingExperiments')} />
         ) : experiments.length === 0 ? (
           <div className="empty-state mt-8">
             <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-4">
@@ -136,7 +133,11 @@ export default function EvalExperimentsDetailsPage({
                     router.push(`/evaluation/${datasetId}/experiments/${item.id}`);
                   }}>
                     <TableCell className="pl-4">
-                      <div className="flex items-center gap-1" data-stop-click>
+                      <div
+                        className="flex items-center gap-1"
+                        data-stop-click
+                        onClick={(e) => e.stopPropagation()}
+                      >
                         <button
                           type="button"
                           className="text-xs font-mono text-primary hover:underline truncate max-w-[110px]"
@@ -211,7 +212,11 @@ export default function EvalExperimentsDetailsPage({
                       )}
                     </TableCell>
 
-                    <TableCell className="text-right pr-3" data-stop-click>
+                    <TableCell
+                      className="text-right pr-3"
+                      data-stop-click
+                      onClick={(e) => e.stopPropagation()}
+                    >
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <Button
@@ -224,16 +229,26 @@ export default function EvalExperimentsDetailsPage({
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end" className="menu-compact">
                           <DropdownMenuItem
-                            onClick={() =>
-                              router.push(`/evaluation/${datasetId}/experiments/${item.id}`)
-                            }
+                            onSelect={(e) => {
+                              e.preventDefault();
+                              setTimeout(
+                                () =>
+                                  router.push(
+                                    `/evaluation/${datasetId}/experiments/${item.id}`,
+                                  ),
+                                0,
+                              );
+                            }}
                           >
                             <Eye />
                             {t('evaluation.viewDetails')}
                           </DropdownMenuItem>
                           <DropdownMenuSeparator />
                           <DropdownMenuItem
-                            onClick={() => deleteExperiment(item.id)}
+                            onSelect={(e) => {
+                              e.preventDefault();
+                              setTimeout(() => deleteExperiment(item.id), 0);
+                            }}
                             className="text-destructive focus:text-destructive"
                           >
                             <Trash2 />

--- a/frontend/app/evaluation/[datasetId]/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/page.tsx
@@ -23,6 +23,7 @@ import RunConfigsPage from '@/app/evaluation/[datasetId]/runconfigs/page';
 import EvaluatorConfigsPage from '@/app/evaluation/[datasetId]/evalconfigs/page';
 import { EvalConfig } from '@/app/evaluation/[datasetId]/types';
 import { HeaderPortal } from '@/components/header-portal';
+import { PageLoading } from '@/components/ui/loading';
 
 type EvalView = 'datasets' | 'experiments' | 'runconfigs' | 'evalconfigs';
 
@@ -59,11 +60,7 @@ export default function EvalExpDetailsPage({
   }, [datasetId, t]);
 
   if (!evaluation) {
-    return (
-      <div className="p-6 text-sm text-muted-foreground" suppressHydrationWarning>
-        {t('evaluation.loading')}
-      </div>
-    );
+    return <PageLoading className="h-full" label={t('evaluation.loading')} />;
   }
 
   return (

--- a/frontend/app/evaluation/[datasetId]/runconfigs/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/runconfigs/page.tsx
@@ -35,12 +35,12 @@ import {
   Pencil,
   Trash2,
   Settings2,
-  Loader2,
   MoreHorizontal,
   ShieldCheck,
   Check,
   X,
 } from 'lucide-react';
+import { PageLoading } from '@/components/ui/loading';
 import { RunConfigFormDialog } from '@/app/evaluation/components/runconfig-form-dialog';
 import { RunConfig } from '@/app/evaluation/[datasetId]/types';
 import { REACT_PROMPT } from '@/app/common/prompts';
@@ -317,10 +317,7 @@ export default function RunConfigsPage({
         </div>
 
         {isLoading ? (
-          <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {t('evaluation.loadingConfigs')}
-          </div>
+          <PageLoading label={t('evaluation.loadingConfigs')} />
         ) : evalRunConfigs.length === 0 ? (
           <div className="empty-state mt-4">
             <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-4">

--- a/frontend/app/evaluation/[datasetId]/samples/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/samples/page.tsx
@@ -21,7 +21,6 @@ import {
   UploadIcon,
   Eye,
   Trash2,
-  Loader2,
   Pencil,
   FileText,
   Info,
@@ -65,6 +64,7 @@ import { SampleDetailDialog } from '@/app/evaluation/components/sample-detail-di
 import { useDatasetActions } from '@/app/evaluation/[datasetId]/samples/useDatasetActions';
 import { SampleItem } from '@/app/evaluation/[datasetId]/types';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
+import { PageLoading, Spinner } from '@/components/ui/loading';
 
 export default function EvalDatasetsDetailsPage({
   params,
@@ -451,7 +451,7 @@ export default function EvalDatasetsDetailsPage({
             >
               {uploading ? (
                 <>
-                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                  <Spinner size="sm" className="mr-1" />
                   {t('evaluation.uploading')}
                 </>
               ) : (
@@ -473,10 +473,7 @@ export default function EvalDatasetsDetailsPage({
 
         {/* Content */}
         {isLoading ? (
-          <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {t('common.loading')}
-          </div>
+          <PageLoading />
         ) : datasets.length === 0 ? (
           <div className="empty-state mt-4">
             <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-4">
@@ -624,18 +621,31 @@ export default function EvalDatasetsDetailsPage({
                               </Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end" className="menu-compact">
-                              <DropdownMenuItem onSelect={() => handleEyeClick(item)}>
+                              <DropdownMenuItem
+                                onSelect={(e) => {
+                                  e.preventDefault();
+                                  setTimeout(() => handleEyeClick(item), 0);
+                                }}
+                              >
                                 <Eye />
                                 {t('evaluation.viewDetails')}
                               </DropdownMenuItem>
-                              <DropdownMenuItem onSelect={() => handleEditClick(item)}>
+                              <DropdownMenuItem
+                                onSelect={(e) => {
+                                  e.preventDefault();
+                                  setTimeout(() => handleEditClick(item), 0);
+                                }}
+                              >
                                 <Pencil />
                                 {t('evaluation.edit')}
                               </DropdownMenuItem>
                               <DropdownMenuItem
-                                onSelect={() => {
-                                  setIsRunSingleDetailOpen(true);
-                                  setEditingSample(item);
+                                onSelect={(e) => {
+                                  e.preventDefault();
+                                  setTimeout(() => {
+                                    setEditingSample(item);
+                                    setIsRunSingleDetailOpen(true);
+                                  }, 0);
                                 }}
                               >
                                 <PlayIcon />
@@ -643,7 +653,10 @@ export default function EvalDatasetsDetailsPage({
                               </DropdownMenuItem>
                               <DropdownMenuSeparator />
                               <DropdownMenuItem
-                                onSelect={() => deleteSample(item.id)}
+                                onSelect={(e) => {
+                                  e.preventDefault();
+                                  setTimeout(() => deleteSample(item.id), 0);
+                                }}
                                 className="text-destructive focus:text-destructive"
                               >
                                 <Trash2 />

--- a/frontend/app/evaluation/components/evalconfig-form-dialog.tsx
+++ b/frontend/app/evaluation/components/evalconfig-form-dialog.tsx
@@ -21,7 +21,8 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Loader2, ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
+import { Spinner } from "@/components/ui/loading";
 import { useState, useEffect } from 'react';
 import { LlmConfig } from '@/app/config/model/llm/page';
 import { useRouter } from 'next/navigation';
@@ -210,7 +211,7 @@ export function EvalConfigFormDialog({
           <Button onClick={handleSubmit} disabled={isSaving}>
             {isSaving ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Spinner size="sm" className="mr-2" />
                 {t('evaluation.submitting')}
               </>
             ) : (

--- a/frontend/app/evaluation/components/runconfig-form-dialog.tsx
+++ b/frontend/app/evaluation/components/runconfig-form-dialog.tsx
@@ -32,7 +32,8 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Loader2, ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
+import { Spinner } from "@/components/ui/loading";
 import { useState, useEffect } from 'react';
 import { McpConfig } from '@/app/config/mcp/mcp';
 import { LlmConfig } from '@/app/config/model/llm/page';
@@ -512,7 +513,7 @@ export function RunConfigFormDialog({
           <Button onClick={handleSubmit} disabled={isSaving}>
             {isSaving ? (
               <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Spinner size="sm" className="mr-2" />
                 {t('common.saving')}
               </>
             ) : (

--- a/frontend/app/evaluation/page.tsx
+++ b/frontend/app/evaluation/page.tsx
@@ -19,16 +19,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -47,6 +38,7 @@ import { Badge } from '@/components/ui/badge';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 import { HeaderPortal } from '@/components/header-portal';
+import { PageLoading } from '@/components/ui/loading';
 
 interface Dataset {
   id: string;
@@ -220,9 +212,7 @@ const EvaluationPage = () => {
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="max-w-7xl mx-auto px-6 py-5">
           {loading ? (
-            <div className="text-center py-16 text-sm text-muted-foreground">
-              {t('common.loading')}
-            </div>
+            <PageLoading />
           ) : datasets.length === 0 ? (
             <div className="empty-state mt-8">
               <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-4">
@@ -321,7 +311,11 @@ const EvaluationPage = () => {
                             {formatBeijingTime(dataset.created_at)}
                           </div>
                         </TableCell>
-                        <TableCell className="text-right pr-3" data-stop-click>
+                        <TableCell
+                          className="text-right pr-3"
+                          data-stop-click
+                          onClick={(e) => e.stopPropagation()}
+                        >
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <Button
@@ -345,7 +339,7 @@ const EvaluationPage = () => {
                                   <DropdownMenuItem
                                     onSelect={(e) => {
                                       e.preventDefault();
-                                      setDeleteTarget(dataset);
+                                      setTimeout(() => setDeleteTarget(dataset), 0);
                                     }}
                                     className="text-destructive focus:text-destructive"
                                   >
@@ -378,33 +372,16 @@ const EvaluationPage = () => {
       )}
 
       {/* Delete confirmation */}
-      <AlertDialog
+      <ConfirmDialog
         open={!!deleteTarget}
-        onOpenChange={(open) => !open && setDeleteTarget(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('evaluation.deleteConfirmTitle')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('evaluation.deleteConfirmMessage')}
-              {deleteTarget && (
-                <span className="block mt-2 font-medium text-foreground">
-                  {deleteTarget.name}
-                </span>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => deleteTarget && deleteEval(deleteTarget.id)}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {t('common.delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        title={t('evaluation.deleteConfirmTitle')}
+        description={t('evaluation.deleteConfirmMessage')}
+        target={deleteTarget ? { label: 'Dataset', value: deleteTarget.name } : undefined}
+        onConfirm={() => {
+          if (deleteTarget) deleteEval(deleteTarget.id);
+        }}
+      />
     </div>
   );
 };

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,11 +3,13 @@
 
 @custom-variant dark (&:is(.dark *));
 
-/* 设置中文字体 */
+/* 设置中文字体 + 全局字体渲染优化 */
 html {
   font-family:
     -apple-system,
     BlinkMacSystemFont,
+    "SF Pro Text",
+    "SF Pro Display",
     "Segoe UI",
     "PingFang SC",        /* macOS/iOS 优秀中文字体 */
     "Hiragino Sans GB",   /* macOS 旧版中文字体 */
@@ -18,6 +20,15 @@ html {
     sans-serif,
     "Apple Color Emoji",
     "Segoe UI Emoji";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "cv11", "ss01", "ss03";
+  letter-spacing: -0.005em;
+}
+
+body {
+  font-synthesis-weight: none;
 }
 
 @theme inline {
@@ -744,14 +755,20 @@ html {
   justify-content: space-between;
   width: 100%;
   padding: 5px 8px;
-  border-radius: 8px;
+  border-radius: 6px;
   background: oklch(1 0 0);
   border: 1px solid oklch(0.915 0.008 260);
-  color: oklch(0.205 0.015 265);
+  color: oklch(0.260 0.015 265);
   font-size: 12px;
   font-weight: 500;
-  transition: all 0.15s ease;
+  letter-spacing: -0.01em;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
   box-shadow: 0 1px 2px oklch(0.145 0.014 265 / 0.04);
+}
+.new-chat-btn:hover {
+  background: oklch(0.98 0.005 260);
+  border-color: oklch(0.860 0.010 260);
+  color: oklch(0.145 0.014 265);
 }
 .new-chat-btn:hover {
   border-color: oklch(0.488 0.180 285 / 0.4);
@@ -970,4 +987,34 @@ html {
 
 .dark .markdown-content a:hover::after {
   background-color: oklch(0.620 0.180 285);
+}
+
+/* ============================================================
+ * Loading animations
+ * ============================================================ */
+
+/* Three-dot spinner — primary color pulses in sequence */
+@keyframes pulse-dot {
+  0%, 80%, 100% {
+    opacity: 0.25;
+    transform: scale(0.75);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-pulse-dot-1 { animation: pulse-dot 1.2s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
+.animate-pulse-dot-2 { animation: pulse-dot 1.2s cubic-bezier(0.4, 0, 0.6, 1) infinite 0.15s; }
+.animate-pulse-dot-3 { animation: pulse-dot 1.2s cubic-bezier(0.4, 0, 0.6, 1) infinite 0.3s; }
+
+/* Shimmer for skeleton placeholders */
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.animate-shimmer {
+  animation: shimmer 1.8s linear infinite;
 }

--- a/frontend/app/knowledgebases/[kbId]/files/[fileId]/page.tsx
+++ b/frontend/app/knowledgebases/[kbId]/files/[fileId]/page.tsx
@@ -7,7 +7,6 @@ import {
   Trash2,
   MoreHorizontal,
   Hash,
-  Loader2,
   FileText,
   Save,
 } from 'lucide-react';
@@ -35,16 +34,7 @@ import {
   DialogFooter,
   DialogClose,
 } from '@/components/ui/dialog';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -57,6 +47,7 @@ import { useRouter } from 'next/navigation';
 import { htmlRender } from '@/app/knowledgebases/[kbId]/viewer/htmlRender';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { HeaderPortal } from '@/components/header-portal';
+import { PageLoading, Loading, Spinner } from '@/components/ui/loading';
 
 interface KnowledgeBase {
   id: string;
@@ -187,7 +178,7 @@ export default function KnowledgeBaseFileChunksPage({
   }, [page, fileId, kbId, tenantFetch]);
 
   if (!knowledgebase || !kbfile) {
-    return <div className="p-6 text-sm text-muted-foreground">{t('common.loading')}</div>;
+    return <PageLoading className="h-full" />;
   }
 
   const handlePageChange = (newPage: number) => {
@@ -336,10 +327,7 @@ export default function KnowledgeBaseFileChunksPage({
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="max-w-7xl mx-auto px-6 py-4">
           {kbfilechunksloading ? (
-            <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              {t('common.loading')}
-            </div>
+            <PageLoading />
           ) : kbfilechunks.length === 0 ? (
             <div className="empty-state mt-8">
               <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-4">
@@ -494,7 +482,7 @@ export default function KnowledgeBaseFileChunksPage({
             >
               {isAdding ? (
                 <>
-                  <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+                  <Spinner size="sm" className="mr-1" />
                   {t('common.saving')}
                 </>
               ) : (
@@ -509,35 +497,19 @@ export default function KnowledgeBaseFileChunksPage({
       </Dialog>
 
       {/* Delete confirm */}
-      <AlertDialog
+      <ConfirmDialog
         open={!!deleteTarget}
-        onOpenChange={(o) => {
-          if (!o) {
-            setDeleteTarget(null);
-            setTimeout(() => {
-              document.body.style.pointerEvents = '';
-            }, 0);
-          }
-        }}
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        title={t('knowledgebase.confirmDeleteChunk')}
+        description={t('knowledgebase.deleteChunkHint') || undefined}
+        onConfirm={confirmDelete}
       >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('knowledgebase.confirmDeleteChunk')}</AlertDialogTitle>
-            <AlertDialogDescription className="text-xs">
-              {deleteTarget?.text?.slice(0, 80)}...
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={confirmDelete}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {t('common.delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        {deleteTarget?.text && (
+          <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-[11px] font-mono text-foreground/80 leading-relaxed max-h-[80px] overflow-hidden line-clamp-3">
+            {deleteTarget.text}
+          </div>
+        )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/frontend/app/knowledgebases/[kbId]/page.tsx
+++ b/frontend/app/knowledgebases/[kbId]/page.tsx
@@ -39,19 +39,9 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Checkbox } from '@/components/ui/checkbox';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 import {
-  Loader2,
   CheckCircle,
   XCircle,
   Trash2Icon,
@@ -126,6 +116,7 @@ import { SearchCode, TextSearch, ScanSearch, ChevronDownIcon as ChevronDown, Che
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { HeaderPortal } from '@/components/header-portal';
 import { Settings as SettingsIcon } from 'lucide-react';
+import { Spinner, PageLoading } from '@/components/ui/loading';
 interface KnowledgeBaseFile {
   id: string;
   file_name: string;
@@ -236,6 +227,7 @@ export default function KnowledgeBaseDetailPage(
   } | null>(null); // 上传时使用的 chunk_config
   const [deleting, setDeleting] = useState(false);
   const [reprocessing, setReprocessing] = useState(false);
+  const [deleteFileTarget, setDeleteFileTarget] = useState<{ id: string; file_name: string } | null>(null);
   const [reprocessChunkConfigDialogOpen, setReprocessChunkConfigDialogOpen] = useState(false);
   const [reprocessChunkConfig, setReprocessChunkConfig] = useState<{
     parser_type: string;
@@ -589,7 +581,7 @@ export default function KnowledgeBaseDetailPage(
   }, [fetchKbConfigs]);
 
   if (!knowledgebase) {
-    return <div className="p-6">{loadingMsg}</div>;
+    return <PageLoading className="h-full" label={loadingMsg} />;
   }
 
   const handleSaveSuccess = async (kb: KbConfig) => {
@@ -1755,7 +1747,7 @@ export default function KnowledgeBaseDetailPage(
                       >
                         {reprocessing ? (
                           <>
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            <Spinner size="sm" className="mr-2" />
                             {t('knowledgebase.processing')}
                           </>
                         ) : (
@@ -1773,7 +1765,7 @@ export default function KnowledgeBaseDetailPage(
                       >
                         {deleting ? (
                           <>
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            <Spinner size="sm" className="mr-2" />
                             {t('knowledgebase.deleting')}
                           </>
                         ) : (
@@ -1783,43 +1775,36 @@ export default function KnowledgeBaseDetailPage(
                           </>
                         )}
                       </Button>
-                      <AlertDialog open={showBatchReprocessDialog} onOpenChange={setShowBatchReprocessDialog}>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>{t('knowledgebase.confirmBatchReparse')}</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              {t('knowledgebase.confirmBatchReparseDesc', { count: selectedFiles.size })}
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-                            <AlertDialogAction
-                              onClick={handleBatchReprocessFiles}
-                            >
-                              {t('knowledgebase.confirmReparse')}
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                      <AlertDialog open={showBatchDeleteDialog} onOpenChange={setShowBatchDeleteDialog}>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>{t('knowledgebase.confirmBatchDelete')}</AlertDialogTitle>
-                            <AlertDialogDescription>
-                              {t('knowledgebase.confirmBatchDeleteDesc', { count: selectedFiles.size })}
-                            </AlertDialogDescription>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-                            <AlertDialogAction
-                              onClick={handleBatchDeleteFiles}
-                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                            >
-                              {t('knowledgebase.confirmDelete')}
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
+                      <ConfirmDialog
+                        open={showBatchReprocessDialog}
+                        onOpenChange={setShowBatchReprocessDialog}
+                        variant="warning"
+                        title={t('knowledgebase.confirmBatchReparse')}
+                        description={t('knowledgebase.confirmBatchReparseDesc', { count: selectedFiles.size })}
+                        confirmLabel={t('knowledgebase.confirmReparse')}
+                        onConfirm={handleBatchReprocessFiles}
+                      />
+                      <ConfirmDialog
+                        open={showBatchDeleteDialog}
+                        onOpenChange={setShowBatchDeleteDialog}
+                        title={t('knowledgebase.confirmBatchDelete')}
+                        description={t('knowledgebase.confirmBatchDeleteDesc', { count: selectedFiles.size })}
+                        confirmLabel={t('knowledgebase.confirmDelete')}
+                        onConfirm={handleBatchDeleteFiles}
+                      />
+                      <ConfirmDialog
+                        open={!!deleteFileTarget}
+                        onOpenChange={(o) => !o && setDeleteFileTarget(null)}
+                        title={t('knowledgebase.confirmDeleteFile') || t('knowledgebase.deleteConfirmTitle')}
+                        description={t('knowledgebase.deleteConfirmMessage')}
+                        target={deleteFileTarget ? { value: deleteFileTarget.file_name } : undefined}
+                        onConfirm={() => {
+                          if (deleteFileTarget) {
+                            handleDeleteFile(deleteFileTarget.id);
+                            setDeleteFileTarget(null);
+                          }
+                        }}
+                      />
                     </>
                   )}
                 </div>
@@ -1940,7 +1925,7 @@ export default function KnowledgeBaseDetailPage(
                       {/* 步骤2: 上传中 - 显示进度条 */}
                       {uploadStep === 'uploading' && (
                         <div className="flex flex-col items-center justify-center py-8 px-4">
-                          <Loader2 className="h-12 w-12 text-primary mb-4 animate-spin" />
+                          <Spinner size="lg" className="mb-4" />
                           <p className="text-sm text-muted-foreground mb-4">{t('knowledgebase.uploadingFile')}</p>
                           <div className="w-full bg-muted rounded-full h-3">
                             <div 
@@ -2320,7 +2305,7 @@ export default function KnowledgeBaseDetailPage(
                       {/* 步骤4: 解析中 */}
                       {uploadStep === 'parsing' && (
                         <div className="flex flex-col items-center justify-center py-8 px-4">
-                          <Loader2 className="h-12 w-12 text-primary mb-4 animate-spin" />
+                          <Spinner size="lg" className="mb-4" />
                           <p className="text-sm text-muted-foreground">{t('knowledgebase.submittingParse')}</p>
                         </div>
                       )}
@@ -2450,17 +2435,17 @@ export default function KnowledgeBaseDetailPage(
                             <TableCell className="text-xs px-2 py-0.5">
                               {file.status === 'pending' ? (
                                 <Badge variant="secondary" className="bg-yellow-100 text-yellow-700 hover:bg-yellow-200 dark:bg-yellow-900/20 dark:text-yellow-400 h-5 px-1.5 text-[10px]">
-                                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                                  <Spinner size="sm" className="mr-1" />
                                   {t('knowledgebase.pendingParse')}
                                 </Badge>
                               ) : file.status === 'parsing' ? (
                                 <Badge variant="secondary" className="bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/20 dark:text-blue-400 h-5 px-1.5 text-[10px]">
-                                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                                  <Spinner size="sm" className="mr-1" />
                                   {t('knowledgebase.parsing')}
                                 </Badge>
                               ) : file.status === 'persisting' ? (
                                 <Badge variant="secondary" className="bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/20 dark:text-blue-400 h-5 px-1.5 text-[10px]">
-                                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                                  <Spinner size="sm" className="mr-1" />
                                   {t('knowledgebase.persisting')}
                                 </Badge>
                               ) : file.status === 'succeeded' ? (
@@ -2510,13 +2495,15 @@ export default function KnowledgeBaseDetailPage(
                                     <DropdownMenuItem
                                       onSelect={(e) => {
                                         e.preventDefault();
-                                        setDropdownOpen(prev => ({
+                                        setDropdownOpen((prev) => ({
                                           ...prev,
-                                          [file.id]: false
+                                          [file.id]: false,
                                         }));
-                                        setPreviewFile(file);
-                                        setPreviewOpen(true);
-                                        loadPreviewContent(file.id);
+                                        setTimeout(() => {
+                                          setPreviewFile(file);
+                                          setPreviewOpen(true);
+                                          loadPreviewContent(file.id);
+                                        }, 0);
                                       }}
                                     >
                                       <span className="text-xs font-medium">{t('knowledgebase.viewFile')}</span>
@@ -2524,11 +2511,11 @@ export default function KnowledgeBaseDetailPage(
                                     <DropdownMenuItem
                                       onSelect={(e) => {
                                         e.preventDefault();
-                                        setDropdownOpen(prev => ({
+                                        setDropdownOpen((prev) => ({
                                           ...prev,
-                                          [file.id]: false
+                                          [file.id]: false,
                                         }));
-                                        checkFileRole(file.id);
+                                        setTimeout(() => checkFileRole(file.id), 0);
                                       }}
                                     >
                                       <span className="text-xs font-medium">{t('knowledgebase.permissionSettings')}</span>
@@ -2536,11 +2523,11 @@ export default function KnowledgeBaseDetailPage(
                                     <DropdownMenuItem
                                       onSelect={(e) => {
                                         e.preventDefault();
-                                        setDropdownOpen(prev => ({
+                                        setDropdownOpen((prev) => ({
                                           ...prev,
-                                          [file.id]: false
+                                          [file.id]: false,
                                         }));
-                                        handleOpenMetadata(file.id);
+                                        setTimeout(() => handleOpenMetadata(file.id), 0);
                                       }}
                                     >
                                       <span className="text-xs font-medium">{t('knowledgebase.metadata')}</span>
@@ -2548,13 +2535,15 @@ export default function KnowledgeBaseDetailPage(
                                     <DropdownMenuItem
                                       onSelect={(e) => {
                                         e.preventDefault();
-                                        setDropdownOpen(prev => ({
+                                        setDropdownOpen((prev) => ({
                                           ...prev,
-                                          [file.id]: false
+                                          [file.id]: false,
                                         }));
-                                        setCurrentFileId(file.id);
-                                        setFileSource(file.file_source || '');
-                                        setFileSourceOpen(true);
+                                        setTimeout(() => {
+                                          setCurrentFileId(file.id);
+                                          setFileSource(file.file_source || '');
+                                          setFileSourceOpen(true);
+                                        }, 0);
                                       }}
                                     >
                                       <span className="text-xs font-medium">{t('knowledgebase.sourceLink')}</span>
@@ -2562,28 +2551,33 @@ export default function KnowledgeBaseDetailPage(
                                     <DropdownMenuItem
                                       onSelect={(e) => {
                                         e.preventDefault();
-                                        setDropdownOpen(prev => ({
+                                        setDropdownOpen((prev) => ({
                                           ...prev,
-                                          [file.id]: false
+                                          [file.id]: false,
                                         }));
-                                        handleReprocessFile(file.id);
+                                        setTimeout(() => handleReprocessFile(file.id), 0);
                                       }}
                                     >
-                                      <span className="text-xs font-medium">{t('knowledgebase.reprocess')}</span> 
+                                      <span className="text-xs font-medium">{t('knowledgebase.reprocess')}</span>
                                     </DropdownMenuItem>
                                     <DropdownMenuSeparator />
                                     <DropdownMenuItem
                                       onSelect={(e) => {
                                         e.preventDefault();
-                                        setDropdownOpen(prev => ({
+                                        setDropdownOpen((prev) => ({
                                           ...prev,
-                                          [file.id]: false
+                                          [file.id]: false,
                                         }));
-                                        handleDeleteFile(file.id);
+                                        setTimeout(() => {
+                                          setDeleteFileTarget({
+                                            id: file.id,
+                                            file_name: file.file_name,
+                                          });
+                                        }, 0);
                                       }}
                                       className="text-destructive focus:text-destructive"
                                     >
-                                      <span className="text-xs font-medium">{t('common.delete')}</span> 
+                                      <span className="text-xs font-medium">{t('common.delete')}</span>
                                     </DropdownMenuItem>
                                   </DropdownMenuContent>
                                 </DropdownMenu>
@@ -3070,7 +3064,7 @@ export default function KnowledgeBaseDetailPage(
                       </DialogHeader>
                       {previewLoading ? (
                         <div className="flex items-center justify-center h-full">
-                          <Loader2 className="h-6 w-6 animate-spin" />
+                          <Spinner size="lg" />
                         </div>
                       ) : previewError ? (
                         <div className="text-red-500">{previewError}</div>

--- a/frontend/app/knowledgebases/[kbId]/viewer/html-viewer.tsx
+++ b/frontend/app/knowledgebases/[kbId]/viewer/html-viewer.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useI18n } from '@/app/providers/i18n';
+import { PageLoading } from '@/components/ui/loading';
 export function HtmlViewer({ file_url }: { file_url: string }) {
   const { t } = useI18n();
   const [htmlContent, setHtmlContent] = useState('');
@@ -28,7 +29,7 @@ export function HtmlViewer({ file_url }: { file_url: string }) {
     fetchHtml();
   }, [file_url]);
 
-  if (loading) return <div>{t('common.loading')}</div>;
+  if (loading) return <PageLoading />;
   if (error)
     return (
       <div className="text-red-500">

--- a/frontend/app/knowledgebases/[kbId]/viewer/jsonl-viewer.tsx
+++ b/frontend/app/knowledgebases/[kbId]/viewer/jsonl-viewer.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from '@/components/ui/card'; // shadcn/ui 容器组
 import { ScrollArea } from '@/components/ui/scroll-area'; // 滚动区域支持 [[9]]
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
+import { PageLoading } from '@/components/ui/loading';
 
 export function JsonlViewer({ file_url }: { file_url: string }) {
   const { t } = useI18n();
@@ -37,7 +38,7 @@ export function JsonlViewer({ file_url }: { file_url: string }) {
     fetchData();
   }, [file_url, tenantFetch]);
 
-  if (loading) return <div>{t('common.loading')}</div>;
+  if (loading) return <PageLoading />;
   if (error)
     return (
       <div className="text-red-500">

--- a/frontend/app/knowledgebases/[kbId]/viewer/markdown-viewer.tsx
+++ b/frontend/app/knowledgebases/[kbId]/viewer/markdown-viewer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useI18n } from '@/app/providers/i18n';
+import { PageLoading } from '@/components/ui/loading';
 export function MarkdownViewer({ file_url }: { file_url: string }) {
   const { t } = useI18n();
   const [markdown, setMarkdown] = useState('');
@@ -27,7 +28,7 @@ export function MarkdownViewer({ file_url }: { file_url: string }) {
     fetchMarkdown();
   }, [file_url]);
 
-  if (loading) return <div>{t('common.loading')}</div>;
+  if (loading) return <PageLoading />;
   if (error)
     return (
       <div className="text-red-500">

--- a/frontend/app/knowledgebases/kbmodal.tsx
+++ b/frontend/app/knowledgebases/kbmodal.tsx
@@ -11,7 +11,8 @@ import { KnowledgeBase } from '@/app/knowledgebases/page';
 import type { FC } from 'react';
 import { useState, useEffect } from 'react';
 import { useI18n } from '@/app/providers/i18n';
-import { BookOpen, Check, Loader2 } from 'lucide-react';
+import { BookOpen, Check } from 'lucide-react';
+import { Loading } from '@/components/ui/loading';
 
 export class KbSelection implements KnowledgeBase {
   id: string;
@@ -90,9 +91,8 @@ export const KbModal: FC<KbModalProps> = ({
 
         <div className="max-h-[360px] overflow-y-auto p-2 space-y-0.5">
           {isLoading ? (
-            <div className="flex items-center justify-center gap-2 py-8 text-xs text-muted-foreground">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {t('common.loading')}
+            <div className="flex items-center justify-center py-8">
+              <Loading size="sm" />
             </div>
           ) : error ? (
             <p className="text-xs text-destructive text-center py-6">{error}</p>

--- a/frontend/app/knowledgebases/page.tsx
+++ b/frontend/app/knowledgebases/page.tsx
@@ -19,16 +19,7 @@ import { Badge } from '@/components/ui/badge';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 import { formatFriendlyTime } from '@/lib/time-format';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -38,6 +29,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useRouter } from 'next/navigation';
 import { HeaderPortal } from '@/components/header-portal';
+import { PageLoading } from '@/components/ui/loading';
 
 export interface KnowledgeBase {
   id: string;
@@ -158,9 +150,7 @@ export default function KnowledgeBasePage() {
           </div>
 
           {loading ? (
-            <div className="text-center py-16 text-sm text-muted-foreground">
-              {t('common.loading')}
-            </div>
+            <PageLoading />
           ) : knowledgebases.length === 0 ? (
             <div className="empty-state mt-8">
               <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 text-primary mb-4">
@@ -212,6 +202,7 @@ export default function KnowledgeBasePage() {
                       <div
                         data-stop-click
                         className="opacity-0 group-hover:opacity-100 transition-opacity"
+                        onClick={(e) => e.stopPropagation()}
                       >
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
@@ -234,7 +225,7 @@ export default function KnowledgeBasePage() {
                             <DropdownMenuItem
                               onSelect={(e) => {
                                 e.preventDefault();
-                                setDeleteTarget(kb);
+                                setTimeout(() => setDeleteTarget(kb), 0);
                               }}
                               className="text-destructive focus:text-destructive"
                             >
@@ -283,35 +274,16 @@ export default function KnowledgeBasePage() {
       )}
 
       {/* Delete confirmation */}
-      <AlertDialog
+      <ConfirmDialog
         open={!!deleteTarget}
-        onOpenChange={(open) => !open && setDeleteTarget(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t('knowledgebase.deleteConfirmTitle')}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('knowledgebase.deleteConfirmMessage')}
-              {deleteTarget && (
-                <span className="block mt-2 font-medium text-foreground">
-                  {deleteTarget.name}
-                </span>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => deleteTarget && deleteKnowledgebase(deleteTarget.id)}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {t('common.delete')}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={(o) => !o && setDeleteTarget(null)}
+        title={t('knowledgebase.deleteConfirmTitle')}
+        description={t('knowledgebase.deleteConfirmMessage')}
+        target={deleteTarget ? { label: 'KB', value: deleteTarget.name } : undefined}
+        onConfirm={() => {
+          if (deleteTarget) deleteKnowledgebase(deleteTarget.id);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -35,11 +35,11 @@ export function AppSidebar() {
   return (
     <Sidebar side="left">
       <SidebarHeader>
-        <div className="flex items-center gap-2 px-1.5 py-1.5">
-          <div className="logo-icon flex items-center justify-center w-7 h-7 rounded-lg font-bold text-xs shrink-0">
+        <div className="flex items-center gap-2 px-1.5 py-1">
+          <div className="logo-icon flex items-center justify-center w-6 h-6 rounded-md font-semibold text-[11px] shrink-0">
             P
           </div>
-          <span className="text-sm font-semibold tracking-tight flex-1 truncate">
+          <span className="text-[13px] font-semibold tracking-tight flex-1 truncate">
             PAI-RAG
           </span>
         </div>

--- a/frontend/components/assistant-ui/my_attachment.tsx
+++ b/frontend/components/assistant-ui/my_attachment.tsx
@@ -25,7 +25,8 @@ import {
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button';
 import { DialogContent as DialogPrimitiveContent } from '@radix-ui/react-dialog';
-import { Loader2, CheckCircle, XCircle } from 'lucide-react';
+import { CheckCircle, XCircle } from 'lucide-react';
+import { Spinner } from '@/components/ui/loading';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import { useI18n } from '@/app/providers/i18n';
 
@@ -345,7 +346,7 @@ const AttachmentPreviewDialog: FC<PropsWithChildren> = ({ children }) => {
         <DialogDescription>{t('chat.attachment.fileName')}: {fileName}</DialogDescription>
         {loading ? (
           <div className="flex items-center justify-center p-8">
-            <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            <Spinner size="lg" />
           </div>
         ) : previewType === 'text' && fileContent ? (
           <TextPreview content={fileContent} />
@@ -451,7 +452,7 @@ const AttachmentUI: FC = () => {
                     </>
                   ) : isUploading ? (
                     <>
-                      <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                      <Spinner size="sm" />
                       <span>{t('chat.attachment.uploading')}</span>
                     </>
                   ) : (

--- a/frontend/components/assistant-ui/thread-list.tsx
+++ b/frontend/components/assistant-ui/thread-list.tsx
@@ -97,17 +97,15 @@ const ThreadListItem: FC = () => {
   const createdAt = useThreadCreatedAt(remoteId);
 
   return (
-    <ThreadListItemPrimitive.Root className="group/thread data-[active]:bg-muted hover:bg-muted focus-visible:bg-muted focus-visible:ring-ring flex items-center rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2">
+    <ThreadListItemPrimitive.Root
+      className="group/thread data-[active]:bg-muted hover:bg-muted focus-visible:bg-muted focus-visible:ring-ring flex items-center rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2"
+      title={createdAt ? formatFriendlyTime(createdAt) : undefined}
+    >
       <ThreadListItemPrimitive.Trigger
         className="flex-1 min-w-0 pl-1.5 pr-1 py-1 text-start"
         onClick={() => router.push('/')}
       >
         <ThreadListItemTitle />
-        {createdAt && (
-          <p className="text-[10px] text-muted-foreground truncate mt-0.5">
-            {formatFriendlyTime(createdAt)}
-          </p>
-        )}
       </ThreadListItemPrimitive.Trigger>
       <ThreadListItemDelete />
     </ThreadListItemPrimitive.Root>
@@ -117,7 +115,10 @@ const ThreadListItem: FC = () => {
 const ThreadListItemTitle: FC = () => {
   const { t } = useI18n();
   return (
-    <p className="text-xs truncate leading-tight" suppressHydrationWarning>
+    <p
+      className="text-[12px] truncate leading-tight text-sidebar-foreground/90"
+      suppressHydrationWarning
+    >
       <ThreadListItemPrimitive.Title fallback={t('chat.threadList.newSession')} />
     </p>
   );
@@ -128,7 +129,7 @@ const ThreadListItemDelete: FC = () => {
   return (
     <ThreadListItemPrimitive.Delete asChild>
       <TooltipIconButton
-        className="shrink-0 h-5 w-5 mr-0.5 p-0 text-muted-foreground/60 hover:text-destructive opacity-0 group-hover/thread:opacity-100 transition-opacity"
+        className="shrink-0 h-5 w-5 mr-0.5 p-0 text-sidebar-foreground/40 hover:text-destructive opacity-0 group-hover/thread:opacity-100 transition-opacity"
         variant="ghost"
         tooltip={t('chat.threadList.deleteThread')}
       >

--- a/frontend/components/assistant-ui/tool-ui.tsx
+++ b/frontend/components/assistant-ui/tool-ui.tsx
@@ -10,9 +10,9 @@ import {
   BookCheckIcon,
   Code2,
   ChevronRight,
-  Loader2,
   AlertCircle,
 } from 'lucide-react';
+import { Spinner } from '@/components/ui/loading';
 import { Badge } from '@/components/ui/badge';
 import { PhotoProvider, PhotoView } from 'react-photo-view';
 import { MarkdownRenderer } from '@/components/customized/markdown/markdown';
@@ -64,7 +64,7 @@ const RunningBubble: FC<{
   detail?: string;
 }> = ({ icon, label, detail }) => (
   <div className="my-1 inline-flex items-center gap-1.5 rounded-md border border-primary/25 bg-primary/5 px-2 py-1 text-[11px] text-muted-foreground">
-    <Loader2 className="w-3 h-3 animate-spin text-primary" />
+    <Spinner size="sm" />
     {icon}
     <span>{label}</span>
     {detail !== undefined && detail !== '' && (
@@ -722,7 +722,7 @@ export const PythonInterpreterToolUI = makeAssistantToolUI<PythonInterpreterArgs
           className="w-full flex items-center gap-1.5 px-2 py-1.5 hover:bg-muted/60 transition-colors text-left"
         >
           {isRunning ? (
-            <Loader2 className="w-3 h-3 animate-spin text-primary shrink-0" />
+            <Spinner size="sm" />
           ) : (
             <ChevronRight
               className={`w-3 h-3 text-muted-foreground shrink-0 transition-transform ${

--- a/frontend/components/model-selector/index.tsx
+++ b/frontend/components/model-selector/index.tsx
@@ -9,6 +9,7 @@ import { Check, ChevronsUpDown, Plus, Bot } from 'lucide-react';
 import { useTenantFetch } from '@/hooks/use-tenant-fetch';
 import Link from 'next/link';
 import { useI18n } from '@/app/providers/i18n';
+import { Loading } from '@/components/ui/loading';
 
 interface ModelConfigurationParams {
   id: string;
@@ -125,8 +126,8 @@ export default function ModelSelector({
       >
         <div className="max-h-[420px] overflow-y-auto py-1">
           {loading ? (
-            <div className="py-6 text-center text-xs text-muted-foreground">
-              {t('common.loading')}
+            <div className="py-6 flex justify-center">
+              <Loading size="sm" />
             </div>
           ) : error ? (
             <div className="py-4 px-3 text-center text-xs">

--- a/frontend/components/ui/confirm-dialog.tsx
+++ b/frontend/components/ui/confirm-dialog.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Spinner } from '@/components/ui/loading';
+import { AlertTriangle, Trash2, Info } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useI18n } from '@/app/providers/i18n';
+
+type Variant = 'destructive' | 'warning' | 'info';
+
+const VARIANT_CONFIG: Record<
+  Variant,
+  {
+    icon: React.ReactNode;
+    iconBg: string;
+    iconColor: string;
+    confirmClass: string;
+  }
+> = {
+  destructive: {
+    icon: <Trash2 className="w-4 h-4" />,
+    iconBg: 'bg-destructive/10',
+    iconColor: 'text-destructive',
+    confirmClass:
+      'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+  },
+  warning: {
+    icon: <AlertTriangle className="w-4 h-4" />,
+    iconBg: 'bg-amber-500/10',
+    iconColor: 'text-amber-600',
+    confirmClass: 'bg-amber-600 text-white hover:bg-amber-700',
+  },
+  info: {
+    icon: <Info className="w-4 h-4" />,
+    iconBg: 'bg-primary/10',
+    iconColor: 'text-primary',
+    confirmClass: '',
+  },
+};
+
+export interface ConfirmDialogProps {
+  /** Controlled open state. */
+  open: boolean;
+  /** Called with `false` when the user closes via ESC / overlay / cancel. */
+  onOpenChange: (open: boolean) => void;
+
+  /** Visual style. Defaults to `destructive` since most confirms are deletes. */
+  variant?: Variant;
+  /** Override the default variant icon. */
+  icon?: React.ReactNode;
+
+  /** Main heading, e.g. "是否确认删除?". */
+  title: React.ReactNode;
+  /** Body text or node. Use for descriptive copy. */
+  description?: React.ReactNode;
+  /** Extra custom content rendered between description and footer. */
+  children?: React.ReactNode;
+
+  /** Highlight a target name/id block (name/label row). */
+  target?: {
+    label?: string;
+    value: string;
+  };
+
+  /** Footer button labels — defaults to i18n cancel/delete. */
+  confirmLabel?: string;
+  cancelLabel?: string;
+
+  /** Confirm click. The dialog does NOT auto-close; caller controls via `open`. */
+  onConfirm: () => void | Promise<void>;
+
+  /** When true, confirm button shows a spinner and is disabled. */
+  loading?: boolean;
+  /** Disable the confirm button without showing a spinner. */
+  disabled?: boolean;
+}
+
+/**
+ * Unified confirmation dialog used across delete / warning / info flows.
+ *
+ * The body uses the same three-segment structure as KbModal / McpModal
+ * (bordered header, body, muted footer), so confirms feel like part of
+ * the same family.
+ */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  variant = 'destructive',
+  icon,
+  title,
+  description,
+  children,
+  target,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  loading = false,
+  disabled = false,
+}: ConfirmDialogProps) {
+  const { t } = useI18n();
+  const cfg = VARIANT_CONFIG[variant];
+  const resolvedIcon = icon ?? cfg.icon;
+
+  // Belt-and-suspenders body pointer-events cleanup.
+  //
+  // Radix AlertDialog sets `pointer-events: none` on <body> while open
+  // and restores it on close. But when a Dialog is opened from a
+  // DropdownMenuItem, the menu's close cleanup races with the dialog's
+  // open/close cleanup and sometimes leaves the body frozen. We can't
+  // rely on a single "all done" moment, so whenever the dialog is not
+  // open we forcibly clear the style on an interval for ~700ms. That
+  // outlasts any Radix exit animation but is short enough to not leak.
+  useEffect(() => {
+    if (open) return;
+    let attempts = 0;
+    const id = window.setInterval(() => {
+      document.body.style.pointerEvents = '';
+      if (++attempts >= 7) window.clearInterval(id);
+    }, 100);
+    return () => window.clearInterval(id);
+  }, [open]);
+
+  // If this component unmounts while the dialog is mounted (e.g. parent
+  // route change), make absolutely sure we release the body.
+  useEffect(() => {
+    return () => {
+      document.body.style.pointerEvents = '';
+    };
+  }, []);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="sm:max-w-md gap-0 p-0 overflow-hidden">
+        <AlertDialogHeader className="px-5 pt-5 pb-3 border-b border-border">
+          <AlertDialogTitle className="flex items-center gap-2 text-sm font-semibold">
+            <span
+              className={cn(
+                'inline-flex items-center justify-center w-7 h-7 rounded-md shrink-0',
+                cfg.iconBg,
+                cfg.iconColor,
+              )}
+            >
+              {resolvedIcon}
+            </span>
+            {title}
+          </AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription className="text-xs leading-relaxed mt-0.5 pl-9">
+              {description}
+            </AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+
+        {(target || children) && (
+          <div className="px-5 py-3 space-y-2">
+            {target && (
+              <div className="flex items-center gap-2 px-2.5 py-2 rounded-md bg-muted/40 border border-border">
+                {target.label && (
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground shrink-0">
+                    {target.label}
+                  </span>
+                )}
+                <span className="text-xs font-medium truncate text-foreground">
+                  {target.value}
+                </span>
+              </div>
+            )}
+            {children}
+          </div>
+        )}
+
+        <AlertDialogFooter className="px-5 py-3 border-t border-border bg-muted/20">
+          <AlertDialogCancel disabled={loading} className="h-8 text-xs">
+            {cancelLabel ?? t('common.cancel')}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              if (loading || disabled) {
+                e.preventDefault();
+                return;
+              }
+              onConfirm();
+            }}
+            disabled={loading || disabled}
+            className={cn('h-8 text-xs min-w-[72px]', cfg.confirmClass)}
+          >
+            {loading ? (
+              <Spinner size="sm" />
+            ) : (
+              confirmLabel ?? t('common.delete')
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/components/ui/custom-tool-fallback.tsx
+++ b/frontend/components/ui/custom-tool-fallback.tsx
@@ -2,7 +2,8 @@
 
 import { ToolCallContentPartComponent } from '@assistant-ui/react';
 import React, { useState } from 'react';
-import { ChevronRight, Loader2, Wrench } from 'lucide-react';
+import { ChevronRight, Wrench } from 'lucide-react';
+import { Spinner } from '@/components/ui/loading';
 import { useI18n } from '@/app/providers/i18n';
 
 /** Parse loose JSON-ish strings emitted by LLMs. */
@@ -59,7 +60,7 @@ export const ToolFallback: ToolCallContentPartComponent = ({
   if (isRunning) {
     return (
       <div className="my-1 inline-flex items-center gap-1.5 rounded-md border border-primary/25 bg-primary/5 px-2 py-1 text-[11px] text-muted-foreground">
-        <Loader2 className="w-3 h-3 animate-spin text-primary" />
+        <Spinner size="sm" />
         <Wrench className="w-3 h-3 text-muted-foreground" />
         <span>{t('chat.tools.callingTool')}</span>
         <span className="text-muted-foreground/60">·</span>

--- a/frontend/components/ui/loading.tsx
+++ b/frontend/components/ui/loading.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { useI18n } from '@/app/providers/i18n';
+
+/**
+ * Unified loading primitives for the app.
+ *
+ * - `Spinner` — the base animated indicator (three purple dots pulsing in
+ *   sequence). Use directly when you need the dots without any label.
+ * - `Loading` — spinner + optional label, three sizes. Pick this for
+ *   inline list placeholders, dialog bodies, button states, etc.
+ * - `PageLoading` — full-page centered layout (takes its parent height).
+ *   Use for route-level "waiting for initial data" screens.
+ * - `SkeletonLine` / `SkeletonCard` — shimmering placeholder rects for
+ *   richer list / card skeletons.
+ *
+ * All primitives derive from the theme's `--primary` color so they stay
+ * in sync with the purple accent.
+ */
+
+// ===== Spinner: three pulsing dots =====
+
+const SIZE_DOT: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'w-1 h-1',
+  md: 'w-1.5 h-1.5',
+  lg: 'w-2 h-2',
+};
+
+const SIZE_GAP: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'gap-1',
+  md: 'gap-1.5',
+  lg: 'gap-2',
+};
+
+export function Spinner({
+  size = 'md',
+  className,
+}: {
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}) {
+  const dot = SIZE_DOT[size];
+  const gap = SIZE_GAP[size];
+  return (
+    <span
+      role="status"
+      aria-label="loading"
+      className={cn('inline-flex items-center', gap, className)}
+    >
+      <span
+        className={cn('rounded-full bg-primary animate-pulse-dot-1', dot)}
+      />
+      <span
+        className={cn('rounded-full bg-primary animate-pulse-dot-2', dot)}
+      />
+      <span
+        className={cn('rounded-full bg-primary animate-pulse-dot-3', dot)}
+      />
+    </span>
+  );
+}
+
+// ===== Inline loading: spinner + label =====
+
+const LABEL_SIZE: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'text-[11px]',
+  md: 'text-xs',
+  lg: 'text-sm',
+};
+
+export function Loading({
+  size = 'md',
+  label,
+  className,
+}: {
+  size?: 'sm' | 'md' | 'lg';
+  label?: string;
+  className?: string;
+}) {
+  const { t } = useI18n();
+  const text = label ?? t('common.loading');
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-2 text-muted-foreground',
+        LABEL_SIZE[size],
+        className,
+      )}
+    >
+      <Spinner size={size} />
+      {text && <span>{text}</span>}
+    </span>
+  );
+}
+
+// ===== Full-page / full-area loading =====
+
+export function PageLoading({
+  label,
+  className,
+}: {
+  label?: string;
+  className?: string;
+}) {
+  const { t } = useI18n();
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 py-16 w-full min-h-[240px]',
+        className,
+      )}
+    >
+      <Spinner size="lg" />
+      <span className="text-xs text-muted-foreground">
+        {label ?? t('common.loading')}
+      </span>
+    </div>
+  );
+}
+
+// ===== Skeleton helpers =====
+
+export function SkeletonLine({
+  className,
+  width,
+}: {
+  className?: string;
+  width?: string | number;
+}) {
+  return (
+    <div
+      className={cn(
+        'h-3 rounded-md bg-gradient-to-r from-muted via-muted/60 to-muted bg-[length:200%_100%] animate-shimmer',
+        className,
+      )}
+      style={width !== undefined ? { width } : undefined}
+    />
+  );
+}
+
+export function SkeletonCard({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border bg-card p-4 space-y-2.5',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <div className="w-7 h-7 rounded-md bg-gradient-to-r from-muted via-muted/60 to-muted bg-[length:200%_100%] animate-shimmer" />
+        <SkeletonLine className="flex-1" />
+      </div>
+      <SkeletonLine width="80%" />
+      <SkeletonLine width="60%" />
+    </div>
+  );
+}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -474,7 +474,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-3 overflow-hidden rounded-md p-3 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md px-2 py-1.5 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding,background-color] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-3.5 [&>svg]:shrink-0 [&>svg]:text-sidebar-foreground/70',
   {
     variants: {
       variant: {
@@ -483,9 +483,9 @@ const sidebarMenuButtonVariants = cva(
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: 'h-9 text-sm',
-        sm: 'h-7 text-xs',
-        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
+        default: 'h-8 text-[13px]',
+        sm: 'h-7 text-[12px]',
+        lg: 'h-10 text-sm group-data-[collapsible=icon]:p-0!',
       },
     },
     defaultVariants: {
@@ -643,7 +643,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<'ul'>) {
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        'border-sidebar-border mx-2 flex min-w-0 translate-x-px flex-col gap-0.5 border-l pl-1.5 pr-0.5 py-0.5',
+        'border-sidebar-border/50 mx-2 flex min-w-0 translate-x-px flex-col gap-px border-l pl-1 pr-0.5 py-0.5',
         'group-data-[collapsible=icon]:hidden',
         className,
       )}


### PR DESCRIPTION
## Summary
- Add `ConfirmDialog` primitive to replace scattered `AlertDialog` and `window.confirm()` usages, with aggressive `pointer-events` cleanup that fixes the page-freeze bug when a confirm dialog is opened from a Radix dropdown menu
- Add `Spinner` / `Loading` / `PageLoading` primitives (three-dot pulse animation) and replace ad-hoc `Loader2` / `Skeleton` loaders across the app
- Apply the `e.preventDefault(); setTimeout(() => action(), 0)` pattern to all `DropdownMenuItem onSelect` handlers that open dialogs (apps, knowledgebases, evaluation, config) so Radix's focus-return doesn't race with the dialog mount
- Add `onClick stopPropagation` on dropdown wrappers nested inside clickable rows/cards to prevent React portal events from bubbling into parent navigation handlers
- Misc dialog and style polish across MCP modal, KB modal, eval config dialogs, attachment cards, and chat composer

## Test plan
- [ ] Verify clicking ⋯ → Delete → Cancel on App / KB / Evaluation / Experiment / Sample / Chunk / Config rows no longer freezes the page
- [ ] Verify clicking ⋯ on a clickable row no longer simultaneously triggers row navigation
- [ ] Verify all loading states show the new three-dot pulse loader
- [ ] `cd frontend && npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)