### PR TITLE
ci: trigger publish docker workflow on frontend changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@ on:
     branches: ["feature"]
     paths:
       - 'backend/**'
+      - 'frontend/**'
       - 'alembic/**'
       - 'scripts/**'
       - 'pyproject.toml'

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY poetry.lock pyproject.toml ./
 
 # Copy backend code and install dependencies
 COPY backend ./backend
+COPY integrations ./integrations
 RUN poetry install --no-interaction --no-ansi && \
     rm -rf $POETRY_CACHE_DIR && \
     find /app/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
@@ -73,6 +74,7 @@ COPY --from=frontend-builder /app/frontend /app/frontend
 COPY resources ./resources
 COPY scripts ./scripts
 COPY backend ./backend
+COPY integrations ./integrations
 COPY alembic ./alembic
 COPY alembic.ini ./
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -25,6 +25,7 @@ COPY poetry.lock pyproject.toml ./
 
 # Copy backend code and install dependencies
 COPY backend ./backend
+COPY integrations ./integrations
 RUN poetry install --no-interaction --no-ansi && \
     rm -rf $POETRY_CACHE_DIR && \
     find /app/.venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
@@ -48,6 +49,7 @@ COPY --from=python-builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 COPY resources ./resources
 COPY scripts ./scripts
 COPY backend ./backend
+COPY integrations ./integrations
 COPY alembic ./alembic
 COPY alembic.ini ./
 


### PR DESCRIPTION
## Summary
- Add `frontend/**` to the paths filter of `.github/workflows/docker.yml` so frontend-only changes also publish a new image
- `docker-api.yml` is intentionally left untouched — the api image only needs to rebuild on backend changes

## Test plan
- [ ] Push a frontend-only change to `feature` and confirm the Publish Docker workflow runs