### PR TITLE
Unify page padding, sidebar alignment, card polish, chat bubble fix

### DIFF
--- a/frontend/app/apps/page.tsx
+++ b/frontend/app/apps/page.tsx
@@ -100,7 +100,7 @@ const ChatbotPage = () => {
       </HeaderPortal>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <div className="max-w-7xl mx-auto px-6 py-5">
+        <div className="p-6">
           {loading ? (
             <PageLoading />
           ) : chatbots.length === 0 ? (
@@ -131,7 +131,7 @@ const ChatbotPage = () => {
                       router.push(`/apps/${bot.app_id}`);
                     }}
                     key={bot.id}
-                    className="group relative cursor-pointer flex flex-col gap-0 p-4 rounded-xl border border-border bg-card card-hover-glow transition-all duration-200"
+                    className="group relative cursor-pointer flex flex-col gap-0 p-5 rounded-xl border border-border bg-card card-hover-glow transition-all duration-200"
                   >
                     {/* Top: avatar + title + more menu */}
                     <div className="flex items-start gap-3">
@@ -189,14 +189,14 @@ const ChatbotPage = () => {
                     </div>
 
                     {/* Description */}
-                    <CardContent className="px-0 pt-3 pb-3 flex-1">
+                    <CardContent className="px-0 pt-4 pb-4 flex-1">
                       <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">
                         {bot.description || t('knowledgebase.noDescription')}
                       </p>
                     </CardContent>
 
                     {/* Footer */}
-                    <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground pt-2 border-t border-border">
+                    <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                       <Clock className="w-3 h-3" />
                       <span className="truncate">{formatBeijingTime(bot.updated_at)}</span>
                     </div>

--- a/frontend/app/config/layout.tsx
+++ b/frontend/app/config/layout.tsx
@@ -83,9 +83,9 @@ export default function ConfigLayout({ children }: { children: React.ReactNode }
         </div>
       </div>
 
-      {/* Content — uniform width wrapper for all config sub-pages */}
+      {/* Content — uniform 24px padding for all config sub-pages */}
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <div className="max-w-6xl mx-auto w-full">{children}</div>
+        <div className="p-6 w-full">{children}</div>
       </div>
     </div>
   );

--- a/frontend/app/config/model/page.tsx
+++ b/frontend/app/config/model/page.tsx
@@ -10,7 +10,7 @@ export default function ModelConfigPage() {
   const { t } = useI18n();
 
   return (
-    <div id="model" className="px-6 py-4">
+    <div id="model">
       <div className="space-y-4 pb-6">
         <LlmConfigPage />
         <EmbConfigPage />

--- a/frontend/app/config/role/page.tsx
+++ b/frontend/app/config/role/page.tsx
@@ -16,7 +16,7 @@ export default function RoleConfigPage() {
   const { t } = useI18n();
 
   return (
-    <div id="access-control" className="px-6 py-4">
+    <div id="access-control">
       <Tabs defaultValue="roles">
         <TabsList className="tabs-modern flex-none">
           <TabsTrigger value="roles" className="px-4">

--- a/frontend/app/evaluation/[datasetId]/evalconfigs/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/evalconfigs/page.tsx
@@ -159,7 +159,7 @@ export default function EvaluatorConfigsPage({
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-3">
+      <div className="flex-1 min-h-0 overflow-y-auto p-6">
         {/* Toolbar */}
         <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
           <p className="text-[11px] text-muted-foreground">

--- a/frontend/app/evaluation/[datasetId]/experiments/[expId]/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/experiments/[expId]/page.tsx
@@ -435,7 +435,7 @@ export default function ExperimentDetailPage({ params }: { params: Promise<{ dat
         mode="view"
       />
 
-      <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+      <div className="flex-1 overflow-y-auto p-6 space-y-4">
         {/* Summary stats row */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
           <div className="rounded-lg border border-border bg-card px-3 py-2">

--- a/frontend/app/evaluation/[datasetId]/experiments/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/experiments/page.tsx
@@ -79,7 +79,7 @@ export default function EvalExperimentsDetailsPage({
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-3">
+      <div className="flex-1 min-h-0 overflow-y-auto p-6">
         {isLoading ? (
           <PageLoading label={t('evaluation.loadingExperiments')} />
         ) : experiments.length === 0 ? (

--- a/frontend/app/evaluation/[datasetId]/runconfigs/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/runconfigs/page.tsx
@@ -288,7 +288,7 @@ export default function RunConfigsPage({
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-3">
+      <div className="flex-1 min-h-0 overflow-y-auto p-6">
         {/* Toolbar */}
         <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
           <p className="text-[11px] text-muted-foreground">

--- a/frontend/app/evaluation/[datasetId]/samples/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/samples/page.tsx
@@ -381,7 +381,7 @@ export default function EvalDatasetsDetailsPage({
         onSave={dialogMode === 'edit' ? handleSaveEdit : undefined}
       />
 
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-3">
+      <div className="flex-1 min-h-0 overflow-y-auto p-6">
         {/* Toolbar */}
         <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
           <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">

--- a/frontend/app/evaluation/page.tsx
+++ b/frontend/app/evaluation/page.tsx
@@ -210,7 +210,7 @@ const EvaluationPage = () => {
       </HeaderPortal>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <div className="max-w-7xl mx-auto px-6 py-5">
+        <div className="p-6">
           {loading ? (
             <PageLoading />
           ) : datasets.length === 0 ? (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -321,31 +321,33 @@ body {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 14px;
+  gap: 12px;
+  padding: 18px;
   border-radius: 12px;
   border: 1px solid oklch(0.915 0.008 260);
   background: oklch(1 0 0);
+  box-shadow: 0 1px 2px oklch(0 0 0 / 0.03), 0 1px 3px oklch(0 0 0 / 0.04);
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 .model-card:hover {
   border-color: oklch(0.488 0.180 285 / 0.35);
-  box-shadow: 0 6px 20px oklch(0.488 0.180 285 / 0.08);
+  box-shadow: 0 0 0 1px oklch(0.488 0.180 285 / 0.18), 0 6px 20px oklch(0.488 0.180 285 / 0.1);
 }
 .dark .model-card {
   background: oklch(0.185 0.018 265);
   border-color: oklch(0.280 0.018 265);
+  box-shadow: 0 1px 2px oklch(0 0 0 / 0.2), 0 1px 3px oklch(0 0 0 / 0.25);
 }
 .dark .model-card:hover {
   border-color: oklch(0.620 0.180 285 / 0.4);
-  box-shadow: 0 6px 24px oklch(0.620 0.180 285 / 0.12);
+  box-shadow: 0 0 0 1px oklch(0.620 0.180 285 / 0.22), 0 6px 24px oklch(0.620 0.180 285 / 0.12);
 }
 
 /* Brand-icon square for model cards (renders first letter of model) */
 .model-icon {
-  width: 34px;
-  height: 34px;
-  border-radius: 8px;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -489,13 +491,28 @@ body {
   height: 11px !important;
 }
 
+/* Sidebar content alignment: unify horizontal padding to 12px and
+ * vertical row gap to 4px so logo, nav items, and conversation list
+ * share the same left/right offset from the sidebar edge. */
+[data-sidebar="header"],
+[data-sidebar="footer"] {
+  padding-inline: 12px !important;
+  padding-block: 8px !important;
+}
+[data-sidebar="menu-button"],
+[data-sidebar="menu-sub-button"] {
+  padding-inline: 12px !important;
+}
+[data-sidebar="menu"] {
+  gap: 4px !important;
+}
+
 /* Setting page wrapper (standard layout for config sub-pages).
- * Width is now controlled by the parent ConfigLayout (max-w-6xl);
- * this class only provides padding + vertical rhythm. */
+ * Outer 24px padding is provided by ConfigLayout; this class only
+ * controls vertical rhythm between sections. */
 .settings-page {
   display: flex;
   flex-direction: column;
-  padding: 16px 24px 24px;
   gap: 16px;
 }
 .settings-page-header {
@@ -788,15 +805,19 @@ body {
 
 /* Card hover glow effect */
 .card-hover-glow {
-  transition: box-shadow 0.25s ease, border-color 0.25s ease;
+  box-shadow: 0 1px 2px oklch(0 0 0 / 0.03), 0 1px 3px oklch(0 0 0 / 0.04);
+  transition: box-shadow 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
 }
 .card-hover-glow:hover {
-  box-shadow: 0 0 0 1px oklch(0.488 0.180 285 / 0.15), 0 4px 16px oklch(0.488 0.180 285 / 0.08);
-  border-color: oklch(0.488 0.180 285 / 0.3);
+  box-shadow: 0 0 0 1px oklch(0.488 0.180 285 / 0.18), 0 6px 20px oklch(0.488 0.180 285 / 0.1);
+  border-color: oklch(0.488 0.180 285 / 0.35);
+}
+.dark .card-hover-glow {
+  box-shadow: 0 1px 2px oklch(0 0 0 / 0.2), 0 1px 3px oklch(0 0 0 / 0.25);
 }
 .dark .card-hover-glow:hover {
-  box-shadow: 0 0 0 1px oklch(0.620 0.180 285 / 0.2), 0 4px 20px oklch(0.620 0.180 285 / 0.1);
-  border-color: oklch(0.620 0.180 285 / 0.3);
+  box-shadow: 0 0 0 1px oklch(0.620 0.180 285 / 0.22), 0 6px 24px oklch(0.620 0.180 285 / 0.12);
+  border-color: oklch(0.620 0.180 285 / 0.32);
 }
 
 /* Chunk card — left border accent */

--- a/frontend/app/knowledgebases/[kbId]/files/[fileId]/page.tsx
+++ b/frontend/app/knowledgebases/[kbId]/files/[fileId]/page.tsx
@@ -325,7 +325,7 @@ export default function KnowledgeBaseFileChunksPage({
       </HeaderPortal>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <div className="max-w-7xl mx-auto px-6 py-4">
+        <div className="p-6">
           {kbfilechunksloading ? (
             <PageLoading />
           ) : kbfilechunks.length === 0 ? (

--- a/frontend/app/knowledgebases/page.tsx
+++ b/frontend/app/knowledgebases/page.tsx
@@ -136,7 +136,7 @@ export default function KnowledgeBasePage() {
       </HeaderPortal>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <div className="max-w-7xl mx-auto px-6 py-5">
+        <div className="p-6">
           {/* Mobile-only search bar */}
           <div className="relative mb-4 sm:hidden">
             <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground w-3.5 h-3.5" />
@@ -184,7 +184,7 @@ export default function KnowledgeBasePage() {
                       router.push(`/knowledgebases/${kb.id}`);
                     }}
                     key={kb.id}
-                    className="group relative cursor-pointer flex flex-col gap-0 p-4 rounded-xl border border-border bg-card card-hover-glow transition-all duration-200"
+                    className="group relative cursor-pointer flex flex-col gap-0 p-5 rounded-xl border border-border bg-card card-hover-glow transition-all duration-200"
                   >
                     {/* Top: avatar + title + more menu */}
                     <div className="flex items-start gap-3">
@@ -238,22 +238,23 @@ export default function KnowledgeBasePage() {
                     </div>
 
                     {/* Description */}
-                    <CardContent className="px-0 pt-3 pb-3 flex-1">
+                    <CardContent className="px-0 pt-4 pb-4 flex-1">
                       <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">
                         {kb.description || t('knowledgebase.noDescription')}
                       </p>
                     </CardContent>
 
-                    {/* Footer: file count + time */}
-                    <div className="flex items-center justify-between gap-2 pt-2 border-t border-border">
-                      <Badge variant="outline" className="text-[11px] badge-tech h-5 px-1.5 gap-1">
+                    {/* Footer: file count · time */}
+                    <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                      <span className="inline-flex items-center gap-1">
                         <FileText className="w-3 h-3" />
                         {kb.file_count || 0}
-                      </Badge>
-                      <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                      </span>
+                      <span className="text-border">·</span>
+                      <span className="inline-flex items-center gap-1 truncate">
                         <Clock className="w-3 h-3" />
                         <span className="truncate">{formatFriendlyTime(kb.updated_at)}</span>
-                      </div>
+                      </span>
                     </div>
                   </Card>
                 );

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -35,7 +35,7 @@ export function AppSidebar() {
   return (
     <Sidebar side="left">
       <SidebarHeader>
-        <div className="flex items-center gap-2 px-1.5 py-1">
+        <div className="flex items-center gap-2 py-1">
           <div className="logo-icon flex items-center justify-center w-6 h-6 rounded-md font-semibold text-[11px] shrink-0">
             P
           </div>
@@ -93,7 +93,7 @@ export function AppSidebar() {
       <SidebarRail />
 
       <SidebarFooter>
-        <div className="flex items-center gap-1 px-1">
+        <div className="flex items-center gap-1">
           <SidebarMenuButton asChild size="sm" className="flex-1">
             <Link href="/config/model">
               <Settings />

--- a/frontend/components/assistant-ui/my_attachment.tsx
+++ b/frontend/components/assistant-ui/my_attachment.tsx
@@ -491,7 +491,7 @@ const AttachmentRemove: FC = () => {
 
 export const UserMessageAttachments: FC = () => {
   return (
-    <div className="flex flex-wrap gap-1.5 mb-1 justify-end">
+    <div className="flex flex-wrap gap-1.5 justify-end empty:hidden [&:not(:empty)]:mb-1">
       <MessagePrimitive.Attachments components={{ Attachment: AttachmentUI }} />
     </div>
   );

--- a/frontend/components/assistant-ui/thread.tsx
+++ b/frontend/components/assistant-ui/thread.tsx
@@ -470,10 +470,10 @@ const ComposerAction: FC = () => {
 
 const UserMessage: FC = () => {
   return (
-    <MessagePrimitive.Root className="flex flex-col items-end gap-1 w-full max-w-[var(--thread-max-width)] py-3">
+    <MessagePrimitive.Root className="flex flex-col items-end gap-1 w-full max-w-[var(--thread-max-width)] py-2">
       <div className="flex items-center gap-1 max-w-[90%]">
         <UserActionBar />
-        <div className="msg-user break-words rounded-2xl px-3.5 py-2 text-[13px] leading-relaxed">
+        <div className="msg-user break-words rounded-2xl px-3.5 py-1.5 text-[13px] leading-normal">
           <UserMessageAttachments />
           <MessagePrimitive.Content />
         </div>


### PR DESCRIPTION
## Summary
- All list and detail pages now use a fixed 24px (`p-6`) padding on all sides; removed `max-w-7xl` / `max-w-6xl` centering that produced uneven whitespace on wide screens
- Sidebar header, footer, and menu buttons unified to 12px horizontal padding with 4px row gap so logo, nav items, and conversation list share one vertical edge
- Card polish for apps / knowledgebases / model-config cards: 20px padding, 40px brand icon, soft baseline shadow, 1px purple hover ring, lightweight inline dot separator in the footer
- Chat user bubble no longer feels oversized: empty attachments wrapper is hidden when there are no attachments, and the bubble uses `py-1.5` + `leading-normal` for single-line messages

## Test plan
- [ ] Verify apps / knowledgebases / evaluation list pages have consistent 24px padding from the main content edge on wide screens
- [ ] Verify sidebar logo, nav items, and conversation thread items all align at 12px from the sidebar edge
- [ ] Verify cards on apps / knowledgebases have the new icon size, shadow, and hover ring
- [ ] Verify user chat bubble height is visually compact for single-line messages and expands naturally with attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)