### PR TITLE
feat: support custom prompt template for LLMJudge evaluator

### DIFF
--- a/alembic/versions/d9f2e4a6b8c1_add_evaluator_prompt_template.py
+++ b/alembic/versions/d9f2e4a6b8c1_add_evaluator_prompt_template.py
@@ -1,0 +1,32 @@
+"""add evaluator prompt_template
+
+Revision ID: d9f2e4a6b8c1
+Revises: c8e1f3a2b4d7
+Create Date: 2026-04-17 16:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from db.op.safe_add import safe_add_column
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd9f2e4a6b8c1'
+down_revision: Union[str, Sequence[str], None] = 'c8e1f3a2b4d7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    safe_add_column(
+        'pai_evaluator_config',
+        sa.Column('prompt_template', sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('pai_evaluator_config', 'prompt_template')

--- a/backend/db/models/evaluation/evaluator_config.py
+++ b/backend/db/models/evaluation/evaluator_config.py
@@ -13,6 +13,7 @@ class EvaluatorConfigCreate(SQLModel):
     model_provider_name: Optional[str] = Field(default="openai_like")
     case_sensitive: bool = Field(default=False)
     ignore_punctuation: bool = Field(default=False)
+    prompt_template: Optional[str] = Field(default=None)
 
 class EvaluatorConfigEntity(EvaluatorConfigCreate, table=True):
     __tablename__ = "pai_evaluator_config"

--- a/backend/evaluation/evaluator/utils.py
+++ b/backend/evaluation/evaluator/utils.py
@@ -29,8 +29,10 @@ def create_evaluator(eval_config: dict, eval_llm: LLM = None) -> BaseEvaluator:
         )
     elif eval_type == "LLMJudge":
         assert eval_llm is not None, "Must provide eval llm instance"
+        prompt_template = eval_config.get("prompt_template") or None
         return LLMJudgeEvaluator(
-            llm=eval_llm
+            llm=eval_llm,
+            prompt_template=prompt_template,
         )
 
     else:

--- a/backend/service/tool/evaluation_service.py
+++ b/backend/service/tool/evaluation_service.py
@@ -1108,6 +1108,7 @@ class EvaluationService:
             model_id=config_data.model_id,
             case_sensitive=config_data.case_sensitive,
             ignore_punctuation=config_data.ignore_punctuation,
+            prompt_template=config_data.prompt_template,
             tenant_id=tenant_id,
         )
 
@@ -1162,6 +1163,8 @@ class EvaluationService:
             eval_config.case_sensitive = update_data.case_sensitive
         if update_data.ignore_punctuation is not None:
             eval_config.ignore_punctuation = update_data.ignore_punctuation
+        if update_data.prompt_template is not None:
+            eval_config.prompt_template = update_data.prompt_template
 
         self.session.add(eval_config)
 

--- a/frontend/app/evaluation/[datasetId]/evalconfigs/page.tsx
+++ b/frontend/app/evaluation/[datasetId]/evalconfigs/page.tsx
@@ -41,6 +41,7 @@ const default_evaluator_config: EvaluatorConfig = {
   model_id: '',
   case_sensitive: false,
   ignore_punctuation: false,
+  prompt_template: '',
 };
 
 export default function EvaluatorConfigsPage({
@@ -258,12 +259,19 @@ export default function EvaluatorConfigsPage({
                           </Badge>
                         </div>
                       ) : config.type === 'LLMJudge' ? (
-                        <span className="text-[11px] text-muted-foreground">
-                          {t('evaluation.model')}:{' '}
-                          <span className="font-mono text-foreground/80">
-                            {config.model_id || t('evaluation.notSpecified')}
+                        <div className="flex flex-wrap items-center gap-1">
+                          <span className="text-[11px] text-muted-foreground">
+                            {t('evaluation.model')}:{' '}
+                            <span className="font-mono text-foreground/80">
+                              {config.model_id || t('evaluation.notSpecified')}
+                            </span>
                           </span>
-                        </span>
+                          {config.prompt_template && (
+                            <Badge variant="secondary" className="h-5 px-1.5 text-[10px] font-normal">
+                              {t('evaluation.customPrompt')}
+                            </Badge>
+                          )}
+                        </div>
                       ) : (
                         <span className="text-[11px] text-muted-foreground">—</span>
                       )}

--- a/frontend/app/evaluation/[datasetId]/types.ts
+++ b/frontend/app/evaluation/[datasetId]/types.ts
@@ -39,9 +39,10 @@ export interface EvaluatorConfig {
     id: string;
     name: string;
     type: string;
-    model_id: string;    
+    model_id: string;
     case_sensitive?: boolean;
     ignore_punctuation?: boolean;
+    prompt_template?: string;
 }
 
 export interface ExperimentItem {

--- a/frontend/app/evaluation/components/evalconfig-form-dialog.tsx
+++ b/frontend/app/evaluation/components/evalconfig-form-dialog.tsx
@@ -19,6 +19,7 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ChevronDownIcon } from "lucide-react";
@@ -62,7 +63,8 @@ export function EvalConfigFormDialog({
         type: "",
         model_id: "",
         case_sensitive: false,
-        ignore_punctuation: false
+        ignore_punctuation: false,
+        prompt_template: "",
       }
   );
 
@@ -77,7 +79,8 @@ export function EvalConfigFormDialog({
         type: "",
         model_id: "",
         case_sensitive: false,
-        ignore_punctuation: false
+        ignore_punctuation: false,
+        prompt_template: "",
       });
     }
   }, [mode, config]);
@@ -174,30 +177,53 @@ export function EvalConfigFormDialog({
               )}
 
               {localConfig.type === "LLMJudge" && (
-                <div className="pt-3">
-                  <Label htmlFor="model_id" className="block text-sm mb-2">
-                    {t('evaluation.selectEvaluatorModel')}
-                  </Label>
-                  <Select
-                    value={localConfig.model_id || ""}
-                    onValueChange={(value) => {
-                      setLocalConfig((prev) => ({
-                        ...prev,
-                        model_id: value,
-                      }));
-                    }}
-                  >
-                    <SelectTrigger id="model_id">
-                      <SelectValue placeholder={t('evaluation.selectEvalModel')} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {llms.map((llm) => (
-                        <SelectItem key={llm.model_id} value={llm.model_id}>
-                          {llm.model_id}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                <div className="pt-3 space-y-4">
+                  <div>
+                    <Label htmlFor="model_id" className="block text-sm mb-2">
+                      {t('evaluation.selectEvaluatorModel')}
+                    </Label>
+                    <Select
+                      value={localConfig.model_id || ""}
+                      onValueChange={(value) => {
+                        setLocalConfig((prev) => ({
+                          ...prev,
+                          model_id: value,
+                        }));
+                      }}
+                    >
+                      <SelectTrigger id="model_id">
+                        <SelectValue placeholder={t('evaluation.selectEvalModel')} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {llms.map((llm) => (
+                          <SelectItem key={llm.model_id} value={llm.model_id}>
+                            {llm.model_id}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="prompt_template" className="block text-sm mb-1">
+                      {t('evaluation.customPromptTemplate')}
+                    </Label>
+                    <p className="text-[11px] text-muted-foreground mb-2">
+                      {t('evaluation.customPromptTemplateHint')}
+                    </p>
+                    <Textarea
+                      id="prompt_template"
+                      value={localConfig.prompt_template || ""}
+                      onChange={(e) =>
+                        setLocalConfig((prev) => ({ ...prev, prompt_template: e.target.value }))
+                      }
+                      placeholder={t('evaluation.customPromptTemplatePlaceholder')}
+                      className="font-mono text-xs min-h-[200px]"
+                      rows={10}
+                    />
+                    <p className="text-[10px] text-muted-foreground mt-1">
+                      {t('evaluation.promptPlaceholdersHint')}
+                    </p>
+                  </div>
                 </div>
               )}
             </div>

--- a/frontend/lib/translations.ts
+++ b/frontend/lib/translations.ts
@@ -732,6 +732,11 @@ export const translations: I18nConfig = {
       selectEvaluator: '选择评估器',
       selectEvaluatorModel: '选择评估器模型',
       selectEvalModel: '请选择评估模型',
+      customPromptTemplate: '自定义评估提示词',
+      customPromptTemplateHint: '自定义 LLM 评判器使用的提示词模板。留空则使用默认的正确性评估提示词。',
+      customPromptTemplatePlaceholder: '输入自定义提示词模板...',
+      promptPlaceholdersHint: '可用占位符: {inputs}, {outputs}, {reference_outputs}。输出必须是包含 score, reason, correctness_issues 字段的 JSON。',
+      customPrompt: '自定义提示词',
       new: '新建',
       modify: '修改',
       
@@ -1965,6 +1970,11 @@ export const translations: I18nConfig = {
       selectEvaluator: 'Select Evaluator',
       selectEvaluatorModel: 'Select Evaluator Model',
       selectEvalModel: 'Please select evaluation model',
+      customPromptTemplate: 'Custom Prompt Template',
+      customPromptTemplateHint: 'Customize the prompt template used by the LLM Judge. Leave empty to use the default correctness prompt.',
+      customPromptTemplatePlaceholder: 'Enter custom prompt template...',
+      promptPlaceholdersHint: 'Available placeholders: {inputs}, {outputs}, {reference_outputs}. Output must be JSON with score, reason, correctness_issues fields.',
+      customPrompt: 'Custom Prompt',
       new: 'New',
       modify: 'Modify',
       


### PR DESCRIPTION
## Summary
- Add `prompt_template` field to evaluator config, allowing users to customize the LLM prompt used by LLMJudge evaluator
- Add Alembic migration to add `prompt_template` column to `pai_evaluator_config` table
- Update frontend evalconfig form dialog with prompt template input for LLMJudge type

## Test plan
- [ ] Create a new LLMJudge evaluator config with a custom prompt template via UI
- [ ] Create a new LLMJudge evaluator config without prompt template (should use default CORRECTNESS_PROMPT)
- [ ] Update an existing evaluator config's prompt template
- [ ] Run an experiment using the custom prompt template and verify LLM receives the custom prompt
- [ ] Verify Alembic migration applies cleanly on a fresh database

🤖 Generated with [Claude Code](https://claude.com/claude-code)