### PR TITLE
refactor(db): lazy engine initialization to keep imports side-effect free

### DIFF
--- a/backend/db/db_context.py
+++ b/backend/db/db_context.py
@@ -6,18 +6,18 @@ dotenv.load_dotenv()
 from loguru import logger
 from sqlmodel import SQLModel
 from sqlalchemy import event
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncEngine
 from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
 from contextlib import asynccontextmanager
 from functools import wraps
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Optional
 
 from urllib.parse import quote_plus
 import os
 
 
-def get_async_db_engine():
+def get_async_db_engine() -> AsyncEngine:
     # 从环境变量中读取数据库配置
     if not os.path.exists("./localdata"):
         os.makedirs("./localdata")
@@ -105,13 +105,78 @@ def get_async_db_engine():
         return async_engine
 
 
-async_engine = get_async_db_engine()
-AsyncSessionLocal = async_sessionmaker(
-    bind=async_engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-    autoflush=False,
-)
+# ---------------------------------------------------------------------------
+# Lazy singletons
+# ---------------------------------------------------------------------------
+# The engine and session factory are constructed on first use rather than at
+# module-import time. This keeps `import db.db_context` (and any module that
+# transitively imports it, such as FastAPI routers under `api.*`) free of side
+# effects, which makes unit tests, CLI tools, and Alembic significantly easier
+# to reason about.
+_engine: Optional[AsyncEngine] = None
+_session_factory: Optional[async_sessionmaker] = None
+
+
+def get_engine() -> AsyncEngine:
+    """Return the process-wide async engine, creating it on first access."""
+    global _engine
+    if _engine is None:
+        _engine = get_async_db_engine()
+    return _engine
+
+
+def get_session_factory() -> async_sessionmaker:
+    """Return the process-wide async session factory, bound to the lazy engine."""
+    global _session_factory
+    if _session_factory is None:
+        _session_factory = async_sessionmaker(
+            bind=get_engine(),
+            class_=AsyncSession,
+            expire_on_commit=False,
+            autoflush=False,
+        )
+    return _session_factory
+
+
+# ---------------------------------------------------------------------------
+# Test hooks
+# ---------------------------------------------------------------------------
+def reset_engine_for_test() -> None:
+    """Drop any cached engine/session factory so the next call rebuilds them.
+
+    Intended for unit tests that mutate `DB_TYPE`/`SQLITE_URL` and need a fresh
+    engine. Not safe for production use.
+    """
+    global _engine, _session_factory
+    _engine = None
+    _session_factory = None
+
+
+def set_engine_for_test(engine: AsyncEngine) -> None:
+    """Inject a pre-built engine (e.g. an in-memory mock) for tests."""
+    global _engine, _session_factory
+    _engine = engine
+    _session_factory = None  # force rebuild against the injected engine
+
+
+def set_session_factory_for_test(factory) -> None:
+    """Inject a session factory (e.g. one that yields AsyncMock sessions)."""
+    global _session_factory
+    _session_factory = factory
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility
+# ---------------------------------------------------------------------------
+# Historical callers and tests reference `async_engine` and `AsyncSessionLocal`
+# as module-level attributes. Expose them via PEP 562 `__getattr__` so the
+# import surface is unchanged while the actual construction stays lazy.
+def __getattr__(name):
+    if name == "async_engine":
+        return get_engine()
+    if name == "AsyncSessionLocal":
+        return get_session_factory()
+    raise AttributeError(f"module 'db.db_context' has no attribute {name!r}")
 
 
 # Backwards-compatible alias for the historical misspelling.
@@ -120,7 +185,7 @@ get_async_db_angine = get_async_db_engine
 
 
 async def init_db():
-    async with async_engine.begin() as conn:
+    async with get_engine().begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
 
 
@@ -130,7 +195,7 @@ async def create_db_session() -> AsyncGenerator[AsyncSession, None]:
     Async context manager that owns a SQLAlchemy AsyncSession lifecycle.
 
     Behavior:
-        - Creates a new Session from AsyncSessionLocal.
+        - Creates a new Session from the lazy session factory.
         - On normal exit: commits the session.
         - On exception: rolls back and re-raises.
         - Always closes the session.
@@ -139,7 +204,7 @@ async def create_db_session() -> AsyncGenerator[AsyncSession, None]:
     `get_db_session` (FastAPI dependency) and `with_async_db_session`
     (decorator) both delegate to it to avoid duplication.
     """
-    session = AsyncSessionLocal()
+    session = get_session_factory()()
     try:
         yield session
         await session.commit()

--- a/tests/db/test_db_context.py
+++ b/tests/db/test_db_context.py
@@ -7,6 +7,15 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
+@pytest.fixture(autouse=True)
+def _reset_engine_state():
+    """Each test starts with a fresh lazy engine/session-factory cache."""
+    from db.db_context import reset_engine_for_test
+    reset_engine_for_test()
+    yield
+    reset_engine_for_test()
+
+
 class TestGetAsyncDbEngine:
     @patch.dict(os.environ, {"DB_TYPE": "sqlite", "SQLITE_URL": "sqlite+aiosqlite:///:memory:"}, clear=False)
     @patch("db.db_context.event")
@@ -59,75 +68,121 @@ class TestGetAsyncDbEngine:
         assert get_async_db_angine is get_async_db_engine
 
 
+class TestLazyEngineInit:
+    """Regression tests ensuring `db.db_context` import is side-effect free."""
+
+    def test_get_engine_is_cached(self):
+        from db import db_context
+        with patch("db.db_context.get_async_db_engine") as factory:
+            sentinel = MagicMock(name="engine")
+            factory.return_value = sentinel
+            assert db_context.get_engine() is sentinel
+            assert db_context.get_engine() is sentinel  # cached
+            factory.assert_called_once()
+
+    def test_get_session_factory_is_cached(self):
+        from db import db_context
+        sentinel_engine = MagicMock(name="engine")
+        db_context.set_engine_for_test(sentinel_engine)
+        f1 = db_context.get_session_factory()
+        f2 = db_context.get_session_factory()
+        assert f1 is f2
+
+    def test_set_engine_for_test_rebuilds_session_factory(self):
+        from db import db_context
+        db_context.set_engine_for_test(MagicMock(name="engine-a"))
+        first_factory = db_context.get_session_factory()
+        db_context.set_engine_for_test(MagicMock(name="engine-b"))
+        second_factory = db_context.get_session_factory()
+        assert first_factory is not second_factory
+
+    def test_async_engine_attr_resolves_via_getattr(self):
+        from db import db_context
+        sentinel = MagicMock(name="engine")
+        db_context.set_engine_for_test(sentinel)
+        assert db_context.async_engine is sentinel
+
+    def test_async_session_local_attr_resolves_via_getattr(self):
+        from db import db_context
+        db_context.set_engine_for_test(MagicMock(name="engine"))
+        assert db_context.AsyncSessionLocal is db_context.get_session_factory()
+
+
 class TestGetDbSession:
     async def test_session_commits_on_success(self):
-        from db.db_context import get_db_session
+        from db import db_context
         mock_session = AsyncMock()
-        with patch("db.db_context.AsyncSessionLocal", return_value=mock_session):
-            gen = get_db_session()
-            session = await gen.__anext__()
-            assert session == mock_session
-            try:
-                await gen.__anext__()
-            except StopAsyncIteration:
-                pass
-            mock_session.commit.assert_called_once()
-            mock_session.close.assert_called_once()
+        db_context.set_session_factory_for_test(lambda: mock_session)
+        gen = db_context.get_db_session()
+        session = await gen.__anext__()
+        assert session is mock_session
+        try:
+            await gen.__anext__()
+        except StopAsyncIteration:
+            pass
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
 
     async def test_session_rollbacks_on_error(self):
-        from db.db_context import get_db_session
+        from db import db_context
         mock_session = AsyncMock()
-        with patch("db.db_context.AsyncSessionLocal", return_value=mock_session):
-            gen = get_db_session()
-            session = await gen.__anext__()
-            with pytest.raises(ValueError):
-                await gen.athrow(ValueError("test error"))
-            mock_session.rollback.assert_called_once()
-            mock_session.close.assert_called_once()
+        db_context.set_session_factory_for_test(lambda: mock_session)
+        gen = db_context.get_db_session()
+        session = await gen.__anext__()
+        assert session is mock_session
+        with pytest.raises(ValueError):
+            await gen.athrow(ValueError("test error"))
+        mock_session.rollback.assert_called_once()
+        mock_session.close.assert_called_once()
 
 
 class TestCreateDbSession:
     async def test_context_manager_commits(self):
-        from db.db_context import create_db_session
+        from db import db_context
         mock_session = AsyncMock()
-        with patch("db.db_context.AsyncSessionLocal", return_value=mock_session):
-            async with create_db_session() as session:
-                assert session == mock_session
-            mock_session.commit.assert_called_once()
-            mock_session.close.assert_called_once()
+        db_context.set_session_factory_for_test(lambda: mock_session)
+        async with db_context.create_db_session() as session:
+            assert session is mock_session
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
 
     async def test_context_manager_rollbacks_on_error(self):
-        from db.db_context import create_db_session
+        from db import db_context
         mock_session = AsyncMock()
-        with patch("db.db_context.AsyncSessionLocal", return_value=mock_session):
-            with pytest.raises(ValueError):
-                async with create_db_session() as session:
-                    raise ValueError("test")
-            mock_session.rollback.assert_called_once()
-            mock_session.close.assert_called_once()
+        db_context.set_session_factory_for_test(lambda: mock_session)
+        with pytest.raises(ValueError):
+            async with db_context.create_db_session():
+                raise ValueError("test")
+        mock_session.rollback.assert_called_once()
+        mock_session.close.assert_called_once()
 
 
 class TestWithAsyncDbSession:
     async def test_decorator_injects_session(self):
-        from db.db_context import with_async_db_session
+        from db import db_context
         mock_session = AsyncMock()
-        with patch("db.db_context.AsyncSessionLocal", return_value=mock_session):
-            @with_async_db_session
-            async def my_func(session=None):
-                return "result"
-            result = await my_func()
-            assert result == "result"
-            mock_session.commit.assert_called_once()
-            mock_session.close.assert_called_once()
+        db_context.set_session_factory_for_test(lambda: mock_session)
+
+        @db_context.with_async_db_session
+        async def my_func(session=None):
+            assert session is mock_session
+            return "result"
+
+        result = await my_func()
+        assert result == "result"
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
 
     async def test_decorator_rollbacks_on_error(self):
-        from db.db_context import with_async_db_session
+        from db import db_context
         mock_session = AsyncMock()
-        with patch("db.db_context.AsyncSessionLocal", return_value=mock_session):
-            @with_async_db_session
-            async def my_func(session=None):
-                raise ValueError("test")
-            with pytest.raises(ValueError):
-                await my_func()
-            mock_session.rollback.assert_called_once()
-            mock_session.close.assert_called_once()
+        db_context.set_session_factory_for_test(lambda: mock_session)
+
+        @db_context.with_async_db_session
+        async def my_func(session=None):
+            raise ValueError("test")
+
+        with pytest.raises(ValueError):
+            await my_func()
+        mock_session.rollback.assert_called_once()
+        mock_session.close.assert_called_once()


### PR DESCRIPTION
## Summary
- `db.db_context` no longer constructs the async engine and `AsyncSessionLocal` at import time. Importing any module that pulls in `db.db_context` (every router under `api.*`, every offline helper, every test fixture) now stays free of database side effects.
- `get_engine()` / `get_session_factory()` build and cache the singletons on first use; `init_db()` and `create_db_session()` go through them.
- New test hooks (`set_engine_for_test`, `set_session_factory_for_test`, `reset_engine_for_test`) give unit tests a clean injection seam.
- The historical module-level names `async_engine` and `AsyncSessionLocal` are preserved via PEP 562 `__getattr__` so no existing caller has to change.

## Why
Previously `async_engine = get_async_db_engine()` ran at module load, which meant:
- Importing `api.v1.chat` (or any router) opened the configured DB connection.
- Tests had to either monkey-patch `AsyncSessionLocal` at import time or set up a real SQLite file before importing the app.
- CLI utilities and Alembic ended up triggering pool creation they did not need.

After this change `python -c "import api.v1.chat"` runs without invoking `get_async_db_engine()` (verified by monkey-patching the factory to raise).

## Backwards compatibility
- `from db.db_context import async_engine, AsyncSessionLocal` keeps working via `__getattr__`.
- The deprecated alias `get_async_db_angine` (kept for callers not yet migrated from PR #1) is unaffected.
- Any caller that imported `get_db_session`, `create_db_session`, `with_async_db_session`, `init_db`, or `get_async_db_engine` is unaffected.

## Test plan
- [x] `pytest tests/db/test_db_context.py` — 15/15 pass (added 5 regression tests under `TestLazyEngineInit`).
- [x] Manual acceptance: importing `api.v1.chat`, `api.v1.thread`, and `api.v1.config_apis.knowledgebase` while a sentinel factory raises confirms the engine is never built.
- [x] Pre-commit (ruff / mypy / black / prettier / codespell) — all green.
- [x] Confirmed the `tests/api/config_api/*` teardown error (`'OssFileStore' object has no attribute 'cleanup'`) is pre-existing on `feature` and not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.ai/code)