### PR TITLE
feat(api): unified exception handling decorator + last-resort handler

### DIFF
--- a/backend/api/api_exception.py
+++ b/backend/api/api_exception.py
@@ -1,7 +1,12 @@
+import functools
+import traceback
+from typing import Any, Awaitable, Callable, Optional, TypeVar
+
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
-from typing import Any, Optional
-from pydantic import BaseModel
+from loguru import logger
+from pydantic import BaseModel, ValidationError
+
 from common.chat.response_model import to_dict
 
 
@@ -47,4 +52,132 @@ async def api_exception_handler(request: Request, exc: ApiException):
         status_code=exc.status_code,
         content=response_data,
         headers=exc.headers
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unified router-level error handling
+# ---------------------------------------------------------------------------
+# Routers across the codebase repeat the same try/except scaffolding:
+#
+#     try:
+#         result = await svc.do_something(...)
+#         return success_response(...)
+#     except ValueError as e:
+#         logger.error(...)
+#         raise ApiException(code=400, message=str(e))
+#     except Exception as e:
+#         logger.error(...)
+#         raise ApiException(code=500, message=f"Failed to ...: {e}")
+#
+# This module offers two centralised pieces of infrastructure so individual
+# routers can stop reinventing it:
+#
+# 1. `@handle_api_exceptions(...)` - a decorator that wraps a route handler
+#    and converts common service-layer exceptions into `ApiException` with
+#    consistent logging.
+# 2. `unhandled_exception_handler` - a FastAPI exception handler intended to
+#    be registered against `Exception` so anything that escapes a non-
+#    decorated route still returns a structured JSON body instead of HTML.
+
+F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
+
+
+def handle_api_exceptions(
+    *,
+    action: Optional[str] = None,
+    value_error_code: int = 400,
+    validation_error_code: int = 400,
+    default_code: int = 500,
+) -> Callable[[F], F]:
+    """Convert service-layer exceptions into :class:`ApiException`.
+
+    Args:
+        action: Human-readable verb phrase woven into log lines and the
+            user-facing error message (e.g. ``"create knowledge base"``).
+            Defaults to the wrapped function's name with underscores
+            replaced by spaces.
+        value_error_code: HTTP status code used for :class:`ValueError`
+            (the canonical "invalid input" signal in this codebase).
+        validation_error_code: HTTP status code used for Pydantic
+            :class:`pydantic.ValidationError` raised inside the handler
+            (e.g. when constructing a response model from bad data).
+        default_code: HTTP status code used for any other unexpected
+            exception.
+
+    Behaviour:
+        - :class:`ApiException` / :class:`HTTPException` are re-raised as-is
+          so endpoints can still pick a specific status code at the call
+          site.
+        - :class:`ValueError` is logged at WARNING and converted to
+          ``ApiException(value_error_code, str(e))``.
+        - :class:`pydantic.ValidationError` is logged at WARNING and
+          converted to ``ApiException(validation_error_code, str(e))``.
+        - All other exceptions are logged at ERROR with full traceback and
+          converted to ``ApiException(default_code, f"Failed to {action}: {e}")``.
+
+    Example:
+        >>> @router.get("")
+        ... @handle_api_exceptions(action="get trace config")
+        ... async def get_trace_config(...):
+        ...     return success_response(data=await svc.get(...))
+    """
+
+    def decorator(func: F) -> F:
+        verb = action or func.__name__.replace("_", " ")
+
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except HTTPException:
+                # Covers ApiException too (it subclasses HTTPException).
+                # Routes that hand-craft a specific status code keep that
+                # control instead of being collapsed to 500.
+                raise
+            except ValueError as e:
+                logger.warning(f"Validation error while trying to {verb}: {e}")
+                raise ApiException(code=value_error_code, message=str(e)) from e
+            except ValidationError as e:
+                logger.warning(
+                    f"Pydantic validation error while trying to {verb}: {e}"
+                )
+                raise ApiException(
+                    code=validation_error_code, message=str(e)
+                ) from e
+            except Exception as e:
+                logger.error(
+                    f"Failed to {verb}: {e}\n{traceback.format_exc()}"
+                )
+                raise ApiException(
+                    code=default_code, message=f"Failed to {verb}: {e}"
+                ) from e
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+async def unhandled_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """Last-resort handler for exceptions that escape every other handler.
+
+    Register against ``Exception`` in ``create_app`` so a route that forgets
+    the decorator (or raises during dependency resolution) still gets a
+    structured JSON body. Note: FastAPI dispatches to the most specific
+    handler, so the existing :func:`api_exception_handler` and
+    ``RequestValidationError`` handler continue to take precedence.
+    """
+    logger.error(
+        f"Unhandled exception in {request.method} {request.url.path}: "
+        f"{exc}\n{traceback.format_exc()}"
+    )
+    return JSONResponse(
+        status_code=500,
+        content={
+            "code": 500,
+            "message": f"Internal server error: {type(exc).__name__}",
+            "data": None,
+        },
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,7 +79,11 @@ async def lifespan(app: FastAPI):
 
 def create_app():
     from api.v1.routers import add_chat_router, add_config_router
-    from api.api_exception import ApiException, api_exception_handler
+    from api.api_exception import (
+        ApiException,
+        api_exception_handler,
+        unhandled_exception_handler,
+    )
     from fastapi.exceptions import RequestValidationError
     import api.v1.mcp_server_middleware as mcp_middleware
     from app.log_middleware import CustomLoggingMiddleware
@@ -109,6 +113,11 @@ def create_app():
     setup_propagator(app)
     app.add_exception_handler(ApiException, api_exception_handler)
     app.add_exception_handler(RequestValidationError, validation_exception_handler)
+    # Last-resort handler: anything that escapes the specific handlers above
+    # (e.g. a route that forgot `@handle_api_exceptions` and let an unexpected
+    # error propagate) returns a structured JSON body instead of Starlette's
+    # default HTML "Internal Server Error" page.
+    app.add_exception_handler(Exception, unhandled_exception_handler)
     return app
 
 app = create_app()

--- a/tests/api/test_api_exception.py
+++ b/tests/api/test_api_exception.py
@@ -1,0 +1,181 @@
+"""Tests for the unified API exception handling layer.
+
+Covers:
+    - `handle_api_exceptions` decorator: pass-through, ValueError /
+      ValidationError -> 400, generic Exception -> 500, custom codes,
+      action wording in messages, HTTPException pass-through.
+    - `unhandled_exception_handler`: shape of the JSON body.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../backend"))
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from pydantic import BaseModel, Field, ValidationError
+
+from api.api_exception import (
+    ApiException,
+    handle_api_exceptions,
+    unhandled_exception_handler,
+)
+
+
+class TestHandleApiExceptionsPassThrough:
+    async def test_returns_result_unchanged(self):
+        @handle_api_exceptions(action="do thing")
+        async def ok():
+            return {"hello": "world"}
+
+        assert await ok() == {"hello": "world"}
+
+    async def test_api_exception_is_reraised_as_is(self):
+        @handle_api_exceptions()
+        async def fail():
+            raise ApiException(code=404, message="missing", data={"id": "x"})
+
+        with pytest.raises(ApiException) as exc:
+            await fail()
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "missing"
+        assert exc.value.data == {"id": "x"}
+
+    async def test_http_exception_is_reraised_as_is(self):
+        @handle_api_exceptions()
+        async def fail():
+            raise HTTPException(status_code=418, detail="teapot")
+
+        with pytest.raises(HTTPException) as exc:
+            await fail()
+        assert exc.value.status_code == 418
+        assert exc.value.detail == "teapot"
+        # And it must NOT have been wrapped in ApiException
+        assert not isinstance(exc.value, ApiException)
+
+
+class TestHandleApiExceptionsCoercion:
+    async def test_value_error_becomes_400(self):
+        @handle_api_exceptions(action="create kb")
+        async def fail():
+            raise ValueError("kb name is required")
+
+        with pytest.raises(ApiException) as exc:
+            await fail()
+        assert exc.value.status_code == 400
+        assert "kb name is required" in exc.value.detail
+
+    async def test_pydantic_validation_error_becomes_400(self):
+        class _Model(BaseModel):
+            count: int = Field(..., gt=0)
+
+        @handle_api_exceptions()
+        async def fail():
+            _Model(count=-1)  # raises ValidationError
+
+        with pytest.raises(ApiException) as exc:
+            await fail()
+        assert exc.value.status_code == 400
+
+    async def test_unknown_exception_becomes_500(self):
+        @handle_api_exceptions(action="frobnicate widget")
+        async def fail():
+            raise RuntimeError("boom")
+
+        with pytest.raises(ApiException) as exc:
+            await fail()
+        assert exc.value.status_code == 500
+        assert "frobnicate widget" in exc.value.detail
+        assert "boom" in exc.value.detail
+
+    async def test_action_defaults_to_function_name(self):
+        @handle_api_exceptions()
+        async def list_things():
+            raise RuntimeError("nope")
+
+        with pytest.raises(ApiException) as exc:
+            await list_things()
+        assert "list things" in exc.value.detail
+
+
+class TestHandleApiExceptionsCustomCodes:
+    async def test_custom_value_error_code(self):
+        @handle_api_exceptions(value_error_code=422)
+        async def fail():
+            raise ValueError("bad")
+
+        with pytest.raises(ApiException) as exc:
+            await fail()
+        assert exc.value.status_code == 422
+
+    async def test_custom_default_code(self):
+        @handle_api_exceptions(default_code=503)
+        async def fail():
+            raise RuntimeError("downstream gone")
+
+        with pytest.raises(ApiException) as exc:
+            await fail()
+        assert exc.value.status_code == 503
+
+
+class TestHandleApiExceptionsPreservesMetadata:
+    async def test_preserves_function_name_and_doc(self):
+        @handle_api_exceptions()
+        async def my_endpoint():
+            """The docstring."""
+            return 1
+
+        assert my_endpoint.__name__ == "my_endpoint"
+        assert my_endpoint.__doc__ == "The docstring."
+
+    async def test_chains_original_exception(self):
+        @handle_api_exceptions()
+        async def fail():
+            raise ValueError("root cause")
+
+        with pytest.raises(ApiException) as exc:
+            await fail()
+        assert isinstance(exc.value.__cause__, ValueError)
+        assert str(exc.value.__cause__) == "root cause"
+
+
+class TestUnhandledExceptionHandler:
+    async def test_returns_500_with_structured_body(self):
+        request = MagicMock()
+        request.method = "GET"
+        request.url.path = "/v1/whatever"
+
+        response = await unhandled_exception_handler(
+            request, RuntimeError("kaboom")
+        )
+
+        assert response.status_code == 500
+        body = json.loads(response.body)
+        assert body == {
+            "code": 500,
+            "message": "Internal server error: RuntimeError",
+            "data": None,
+        }
+
+    async def test_includes_exception_type_name_not_value(self):
+        """The body must not leak `str(exc)` to the client; only the class name.
+
+        This guards against accidentally exposing internal details (file paths,
+        stack-trace-like reprs, etc.) in production error responses.
+        """
+        request = MagicMock()
+        request.method = "POST"
+        request.url.path = "/v1/x"
+
+        class _Secret(Exception):
+            pass
+
+        response = await unhandled_exception_handler(
+            request, _Secret("DB password=hunter2")
+        )
+        body = json.loads(response.body)
+        assert "hunter2" not in body["message"]
+        assert "_Secret" in body["message"]


### PR DESCRIPTION
## Summary
- Adds `@handle_api_exceptions(action=..., value_error_code=..., default_code=...)` to `backend/api/api_exception.py`. It converts `ValueError` / `pydantic.ValidationError` to `ApiException(400, ...)`, anything else to `ApiException(500, ...)` with full traceback logging, while re-raising `ApiException` / `HTTPException` untouched so explicit status codes still work.
- Adds `unhandled_exception_handler(request, exc)` and registers it against `Exception` in `create_app()`. Routes that forget the decorator now return a structured JSON body (`code/message/data`) instead of Starlette's default HTML page. The body intentionally leaks only `type(exc).__name__`, never `str(exc)`.
- No router is migrated in this PR; the decorator is purely opt-in. The full migration lands in PR #4.

## Why
Every router endpoint repeats roughly the same try/except scaffolding (counted 50+ sites). The hand-copied code drifts (some catch `ValueError`, some don't; some log only `str(e)` and lose the traceback) and forces every author to remember the convention. Centralising the behaviour fixes the drift, gets full tracebacks in logs, and shrinks future routers.

## Design notes
- `action` argument lets callers control the verb in both the user-facing message and the log line; it defaults to the function name with underscores -> spaces so most call sites need no extra wording.
- Original exceptions are chained via `raise ... from e`, so tracebacks still show the root cause.
- FastAPI dispatches to the most specific handler first, so registering the catch-all on `Exception` does **not** disturb the existing `ApiException` and `RequestValidationError` handlers.
- Security: `unhandled_exception_handler` deliberately does not expose `str(exc)` in the response body, only the class name, to avoid leaking internal state.

## Test plan
- [x] `pytest tests/api/test_api_exception.py` - 13/13 pass.
- [x] `pytest tests/db/test_db_context.py tests/api/test_api_exception.py` - 28/28 pass (PR #2 regression sanity).
- [x] Pre-commit (ruff / mypy / black / prettier / codespell) - all green.
- [x] No router behaviour change yet: all existing endpoints continue to use their hand-rolled try/except; the decorator and global handler are additive.

## Follow-up (PR #4)
Migrate the ~25 config routers + chat / retrieval / files routers to `@handle_api_exceptions`, deleting the duplicated try/except scaffolding.

🤖 Generated with [Claude Code](https://claude.ai/code)