### PR TITLE
refactor(api): migrate remaining v1 routers to @handle_api_exceptions

### DIFF
--- a/backend/api/v1/config_apis/chatapp.py
+++ b/backend/api/v1/config_apis/chatapp.py
@@ -39,7 +39,7 @@ from rag.file_item_utils import to_file_entity
 from typing import Optional, List
 from io import BytesIO
 import json
-from api.api_exception import ApiException
+from api.api_exception import ApiException, handle_api_exceptions
 import traceback
 from loguru import logger
 from common.i18n import i18n
@@ -53,6 +53,7 @@ from db.models.faq_item import FAQItemCreate, FAQItemEntity
 # FAQ routes - MUST be defined before /{id} routes to avoid route conflicts
 # FastAPI matches routes in order, so more specific routes must come first
 @app_router.post("/{app_id}/faqs", response_model=ResponseModel[FAQItemEntity], tags=["FAQ"])
+@handle_api_exceptions(action="create FAQ item", i18n_error_key="api.faq.create_failed", default_code=500)
 async def create_faq_item(
     app_id: str,
     faq_item_create: FAQItemCreate,
@@ -63,34 +64,26 @@ async def create_faq_item(
     rag_service: RagService = Depends(get_rag_service),
 ):
     logger.info(f"Creating FAQ item for app_id: {app_id}")
-    try:
-        # Get chatbot by app_id to get chatbot_id
-        chatbot = await chatapp_service.get_chatapp_by_app_id(app_id=app_id, tenant_id=tenant_id)
-        if not chatbot:
-            raise ApiException(code=404, message=f"Chat App '{app_id}' does not exist.")
+    # Get chatbot by app_id to get chatbot_id
+    chatbot = await chatapp_service.get_chatapp_by_app_id(app_id=app_id, tenant_id=tenant_id)
+    if not chatbot:
+        raise ApiException(code=404, message=f"Chat App '{app_id}' does not exist.")
 
-        if not chatbot.enable_faq or not chatbot.faq_config:
-            raise ApiException(code=400, message="FAQ is not enabled.")
+    if not chatbot.enable_faq or not chatbot.faq_config:
+        raise ApiException(code=400, message="FAQ is not enabled.")
 
-        faq_item = await faq_item_service.create_faq_item(
-            chatbot_id=chatbot.app_id,
-            faq_item_data=faq_item_create,
-            tenant_id=tenant_id,
-        )
-        await faq_item_service.save_faq_to_knowledgebase(faq_item, tenant_id, rag_service)
-        await session.commit()
-        await session.refresh(faq_item)
-        return success_response(data=faq_item, message=i18n.t("api.faq.create_success"))
-    except ValueError as e:
-        logger.error(f"Failed to create FAQ item: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except ApiException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to create FAQ item: {traceback.format_exc()}")
-        raise ApiException(code=500, message=i18n.t("api.faq.create_failed", error=traceback.format_exc()))
+    faq_item = await faq_item_service.create_faq_item(
+        chatbot_id=chatbot.app_id,
+        faq_item_data=faq_item_create,
+        tenant_id=tenant_id,
+    )
+    await faq_item_service.save_faq_to_knowledgebase(faq_item, tenant_id, rag_service)
+    await session.commit()
+    await session.refresh(faq_item)
+    return success_response(data=faq_item, message=i18n.t("api.faq.create_success"))
 
 @app_router.get("/{app_id}/faqs", tags=["FAQ"])
+@handle_api_exceptions(action="list FAQ items", i18n_error_key="api.faq.list_failed", default_code=500)
 async def list_faq_items(
     app_id: str,
     page: int = Query(default=1, ge=1),
@@ -101,29 +94,21 @@ async def list_faq_items(
     faq_item_service: FAQItemService = Depends(get_faq_item_service),
 ):
     logger.info(f"Listing FAQ items for app_id: {app_id}")
-    try:
-        # Get chatbot by app_id to get chatbot_id
-        chatbot = await chatapp_service.get_chatapp_by_app_id(app_id=app_id, tenant_id=tenant_id)
-        if not chatbot:
-            raise ApiException(code=404, message=f"Chat app '{app_id}' does not exist.")
+    # Get chatbot by app_id to get chatbot_id
+    chatbot = await chatapp_service.get_chatapp_by_app_id(app_id=app_id, tenant_id=tenant_id)
+    if not chatbot:
+        raise ApiException(code=404, message=f"Chat app '{app_id}' does not exist.")
 
-        faq_items = await faq_item_service.list_faq_items(
-            chatbot_id=chatbot.app_id,
-            tenant_id=tenant_id,
-            page=page,
-            size=size,
-        )
-        return success_response(data=faq_items, message=i18n.t("api.faq.list_success"))
-    except ValueError as e:
-        logger.error(f"Failed to list FAQ items: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except ApiException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to list FAQ items: {traceback.format_exc()}")
-        raise ApiException(code=500, message=i18n.t("api.faq.list_failed", error=traceback.format_exc()))
+    faq_items = await faq_item_service.list_faq_items(
+        chatbot_id=chatbot.app_id,
+        tenant_id=tenant_id,
+        page=page,
+        size=size,
+    )
+    return success_response(data=faq_items, message=i18n.t("api.faq.list_success"))
 
 @app_router.put("/{app_id}/faqs/{faq_item_id}", response_model=ResponseModel[FAQItemEntity], tags=["FAQ"])
+@handle_api_exceptions(action="update FAQ item", i18n_error_key="api.faq.update_failed", default_code=500)
 async def update_faq_item(
     app_id: str,
     faq_item_id: str,
@@ -133,21 +118,15 @@ async def update_faq_item(
     faq_item_service: FAQItemService = Depends(get_faq_item_service),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        faq_item = await faq_item_service.update_faq_item(
-            id=faq_item_id, update_data=faq_item_update, tenant_id=tenant_id, rag_service=rag_service
-        )
-        await session.commit()
-        await session.refresh(faq_item)
-        return success_response(data=faq_item, message=i18n.t("api.faq.update_success"))
-    except ValueError as e:
-        logger.error(f"Failed to update FAQ item: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to update FAQ item: {traceback.format_exc()}")
-        raise ApiException(code=500, message=i18n.t("api.faq.update_failed", error=traceback.format_exc()))
+    faq_item = await faq_item_service.update_faq_item(
+        id=faq_item_id, update_data=faq_item_update, tenant_id=tenant_id, rag_service=rag_service
+    )
+    await session.commit()
+    await session.refresh(faq_item)
+    return success_response(data=faq_item, message=i18n.t("api.faq.update_success"))
 
 @app_router.delete("/{app_id}/faqs/{faq_item_id}", tags=["FAQ"])
+@handle_api_exceptions(action="delete FAQ item", i18n_error_key="api.faq.delete_failed", default_code=500)
 async def delete_faq_item(
     app_id: str,
     faq_item_id: str,
@@ -156,16 +135,9 @@ async def delete_faq_item(
     faq_item_service: FAQItemService = Depends(get_faq_item_service),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        await faq_item_service.delete_faq_item(id=faq_item_id, tenant_id=tenant_id, rag_service=rag_service)
-        await session.commit()
-        return success_response(message=i18n.t("api.faq.delete_success", id=faq_item_id))
-    except ValueError as e:
-        logger.error(f"Failed to delete FAQ item: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete FAQ item: {traceback.format_exc()}")
-        raise ApiException(code=500, message=i18n.t("api.faq.delete_failed", error=traceback.format_exc()))
+    await faq_item_service.delete_faq_item(id=faq_item_id, tenant_id=tenant_id, rag_service=rag_service)
+    await session.commit()
+    return success_response(message=i18n.t("api.faq.delete_success", id=faq_item_id))
 
 MAX_CHECK_ATTEMPTS = 100
 CHECK_INTERVAL = 3
@@ -437,26 +409,21 @@ async def upload_faq_files(
 
 
 @app_router.post("", response_model=ResponseModel[ChatBotEntity])
+@handle_api_exceptions(action="create chatapp", i18n_error_key="api.app.create_failed", default_code=500)
 async def create_chatbot(
     chatbot_create: ChatBotCreate,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     chatapp_service: ChatappService = Depends(get_chatapp_service),
 ):
-    try:
-        chatbot = await chatapp_service.create_chatapp(app_data=chatbot_create, tenant_id=tenant_id)
-        await session.commit()
-        await session.refresh(chatbot)
-        return success_response(data=chatbot, message=i18n.t("api.app.create_success"))
-    except ValueError as e:
-        logger.error(f"Failed to create chatapp: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create chatapp: {traceback.format_exc()}")
-        raise ApiException(code=500, message=i18n.t("api.app.create_failed", error=traceback.format_exc()))
+    chatbot = await chatapp_service.create_chatapp(app_data=chatbot_create, tenant_id=tenant_id)
+    await session.commit()
+    await session.refresh(chatbot)
+    return success_response(data=chatbot, message=i18n.t("api.app.create_success"))
 
 
 @app_router.get("")
+@handle_api_exceptions(action="list chatapps", i18n_error_key="api.app.list_failed", default_code=500)
 async def get_chatbots(
     app_id: str = None,
     page: int = Query(default=1, ge=1),
@@ -465,24 +432,17 @@ async def get_chatbots(
     session: AsyncSession = Depends(get_db_session),
     chatapp_service: ChatappService = Depends(get_chatapp_service),
 ):
-    try:
-        if not app_id:
-            chatbots = await chatapp_service.list_chatapps(page=page, size=size, tenant_id=tenant_id)
-            return success_response(data=chatbots, message=i18n.t("api.app.list_success"))
-        else:
-            chatbot = await chatapp_service.get_chatapp_by_app_id(app_id=app_id, tenant_id=tenant_id)
-            if not chatbot:
-                raise ApiException(code=404, message=i18n.t("api.app.query_failed", id=app_id))
-            return success_response(data=chatbot, message=i18n.t("api.app.query_success"))
-    except ValueError as e:
-        logger.error(f"Failed to list chatapps: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to list chatapps: {traceback.format_exc()}")
-        raise ApiException(code=500, message=i18n.t("api.app.list_failed", error=traceback.format_exc()))
+    if not app_id:
+        chatbots = await chatapp_service.list_chatapps(page=page, size=size, tenant_id=tenant_id)
+        return success_response(data=chatbots, message=i18n.t("api.app.list_success"))
+    chatbot = await chatapp_service.get_chatapp_by_app_id(app_id=app_id, tenant_id=tenant_id)
+    if not chatbot:
+        raise ApiException(code=404, message=i18n.t("api.app.query_failed", id=app_id))
+    return success_response(data=chatbot, message=i18n.t("api.app.query_success"))
 
 
 @app_router.put("/{id}", response_model=ResponseModel[ChatBotEntity])
+@handle_api_exceptions(action="update chatapp", i18n_error_key="api.app.update_failed", default_code=500)
 async def update_chatbot(
     id: str,
     new_chatbot: ChatBotCreate,
@@ -490,18 +450,12 @@ async def update_chatbot(
     session: AsyncSession = Depends(get_db_session),
     chatapp_service: ChatappService = Depends(get_chatapp_service),
 ):
-    try:
-        chatbot = await chatapp_service.update_chatapp(id=id, update_data=new_chatbot, tenant_id=tenant_id)
-        return success_response(data=chatbot, message=i18n.t("api.app.update_success"))
-    except ValueError as e:
-        logger.error(f"Failed to update chatapp: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to update chatapp: {traceback.format_exc()}")
-        raise ApiException(code=500, message=i18n.t("api.app.update_failed", error=traceback.format_exc()))
+    chatbot = await chatapp_service.update_chatapp(id=id, update_data=new_chatbot, tenant_id=tenant_id)
+    return success_response(data=chatbot, message=i18n.t("api.app.update_success"))
 
 
 @app_router.delete("/{id}")
+@handle_api_exceptions(action="delete chatapp", i18n_error_key="api.app.delete_failed", default_code=500)
 async def delete_chatbot(
     id: str,
     tenant_id: str = Depends(get_tenant_id),
@@ -509,13 +463,6 @@ async def delete_chatbot(
     chatapp_service: ChatappService = Depends(get_chatapp_service),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        await chatapp_service.delete_chatapp(id=id, tenant_id=tenant_id, rag_service=rag_service)
-        await session.commit()
-        return success_response(message=i18n.t("api.app.delete_success", id=id))
-    except ValueError as e:
-        logger.error(f"Failed to delete chatapp: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete chatapp: {traceback.format_exc()}")
-        raise ApiException(code=500, message=i18n.t("api.app.delete_failed", error=traceback.format_exc()))
+    await chatapp_service.delete_chatapp(id=id, tenant_id=tenant_id, rag_service=rag_service)
+    await session.commit()
+    return success_response(message=i18n.t("api.app.delete_success", id=id))

--- a/backend/api/v1/config_apis/code_sandbox.py
+++ b/backend/api/v1/config_apis/code_sandbox.py
@@ -1,6 +1,5 @@
 ### Code sandbox configuration API ###
 
-import traceback
 from fastapi import APIRouter, Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 from db.models.code_sandbox import (
@@ -11,7 +10,7 @@ from common.chat.response_model import success_response, ResponseModel
 from db.db_context import get_db_session
 from service.tool.codesandbox_service import CodesandboxService
 from service.injection import get_codesandbox_service, get_tenant_id
-from api.api_exception import ApiException
+from api.api_exception import ApiException, handle_api_exceptions
 from common.encrypt_utils import decrypt_key
 from loguru import logger
 from common.i18n import i18n
@@ -21,6 +20,7 @@ code_sandbox_router = APIRouter()
 
 
 @code_sandbox_router.post("", response_model=ResponseModel[CodeSandboxConfigRead])
+@handle_api_exceptions(action="add code sandbox config", i18n_error_key="api.code_sandbox.add_failed", default_code=400)
 async def add_code_sandbox_config(
     new_code_sandbox_config: CodeSandboxConfigCreate,
     tenant_id: str = Depends(get_tenant_id),
@@ -31,47 +31,33 @@ async def add_code_sandbox_config(
         logger.error(f"不支持的code sandbox类型{new_code_sandbox_config.type}，仅支持aliyun-fc")
         raise ApiException(code=400, message=i18n.t("api.code_sandbox.unsupported_type", type=new_code_sandbox_config.type))
 
-
-
-    try:
-        code_sandbox_config = await codesandbox_service.create_or_update_codesandbox_config(
-            new_code_sandbox_config, tenant_id=tenant_id
-        )
-        await session.commit()
-        await session.refresh(code_sandbox_config)
-        return success_response(data=code_sandbox_config, message=i18n.t("api.code_sandbox.add_success"))
-    except ValueError as e:
-        logger.error(f"Failed to add code sandbox config: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=i18n.t("api.code_sandbox.add_failed", error=str(e)))
-    except Exception as e:
-        logger.error(f"Failed to add code sandbox config: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=400, message=f"Failed to add code sandbox config: {str(e)}")
+    code_sandbox_config = await codesandbox_service.create_or_update_codesandbox_config(
+        new_code_sandbox_config, tenant_id=tenant_id
+    )
+    await session.commit()
+    await session.refresh(code_sandbox_config)
+    return success_response(data=code_sandbox_config, message=i18n.t("api.code_sandbox.add_success"))
 
 
 @code_sandbox_router.get("", response_model=ResponseModel[CodeSandboxConfigRead])
+@handle_api_exceptions(action="list code sandbox config", i18n_error_key="api.code_sandbox.query_failed", default_code=400)
 async def list_code_sandbox_config(
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     codesandbox_service: CodesandboxService = Depends(get_codesandbox_service),
 ):
-    try:
-        config = await codesandbox_service.get_codesandbox_config_or_create(tenant_id=tenant_id)
-        if not config:
-            logger.warning("No code sandbox config found.")
-            return success_response(data=CodeSandboxConfigRead(), message=i18n.t("api.code_sandbox.query_success"))
-        code_sandbox_config_read = CodeSandboxConfigRead(
-            type=config.type,
-            aliyun_id=config.aliyun_id,
-            interpreter_id=config.interpreter_id,
-            interpreter_name=config.interpreter_name,
-            enabled=config.enabled,
-            timeout_default=config.timeout_default,
-            api_key=decrypt_key(config.encrypted_api_key) if config.encrypted_api_key else None,
-            id=config.id,
-        )
-        return success_response(data=code_sandbox_config_read, message=i18n.t("api.code_sandbox.query_success"))
-    except Exception as e:
-        logger.error(f"Failed to list code sandbox config: {traceback.format_exc()}")
-        raise ApiException(code=400, message=i18n.t("api.code_sandbox.query_failed", error=str(e)))
+    config = await codesandbox_service.get_codesandbox_config_or_create(tenant_id=tenant_id)
+    if not config:
+        logger.warning("No code sandbox config found.")
+        return success_response(data=CodeSandboxConfigRead(), message=i18n.t("api.code_sandbox.query_success"))
+    code_sandbox_config_read = CodeSandboxConfigRead(
+        type=config.type,
+        aliyun_id=config.aliyun_id,
+        interpreter_id=config.interpreter_id,
+        interpreter_name=config.interpreter_name,
+        enabled=config.enabled,
+        timeout_default=config.timeout_default,
+        api_key=decrypt_key(config.encrypted_api_key) if config.encrypted_api_key else None,
+        id=config.id,
+    )
+    return success_response(data=code_sandbox_config_read, message=i18n.t("api.code_sandbox.query_success"))

--- a/backend/api/v1/config_apis/evaluation.py
+++ b/backend/api/v1/config_apis/evaluation.py
@@ -1,5 +1,4 @@
 ### Evaluation configuration API ###
-import traceback
 from fastapi import APIRouter, Depends, File, Query, UploadFile
 from sqlmodel.ext.asyncio.session import AsyncSession
 from db.models.evaluation.dataset import DatasetEntity, DatasetCreate, DatasetSampleEntity
@@ -20,32 +19,27 @@ from db.models.evaluation.evaluator_config import (
 from rag.evaluation_tool import eval_client
 from service.tool.evaluation_service import EvaluationService
 from service.injection import get_evaluation_service, get_tenant_id
-from api.api_exception import ApiException
+from api.api_exception import ApiException, handle_api_exceptions
 from loguru import logger
 
 
 evaluation_router = APIRouter()
 
 @evaluation_router.post("", response_model=ResponseModel[DatasetEntity])
+@handle_api_exceptions(action="create dataset")
 async def create_dataset(
     dataset_data: DatasetCreate,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
-    try:
-        dataset_entity = await evaluation_service.create_dataset(dataset_data=dataset_data, tenant_id=tenant_id)
-        await session.refresh(dataset_entity)
-        return success_response(data=dataset_entity, message="Created dataset successfully")
-    except ValueError as e:
-        logger.error(f"Failed to create dataset: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create dataset: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Dataset creation failed: '{e}'.")
+    dataset_entity = await evaluation_service.create_dataset(dataset_data=dataset_data, tenant_id=tenant_id)
+    await session.refresh(dataset_entity)
+    return success_response(data=dataset_entity, message="Created dataset successfully")
 
 
 @evaluation_router.get("")
+@handle_api_exceptions(action="list datasets")
 async def list_datasets(
     page: int = Query(default=1, ge=1),
     size: int = Query(default=10, le=1000),
@@ -54,15 +48,12 @@ async def list_datasets(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Listing datasets with tenant_id: {tenant_id}, page: {page}, size: {size}.")
-    try:
-        datasets = await evaluation_service.list_datasets(tenant_id=tenant_id, page=page, size=size)
-        return success_response(data=datasets, message="Listed datasets successfully")
-    except Exception as e:
-        logger.error(f"Failed to list datasets: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Failed to list datasets: '{e}'.")
+    datasets = await evaluation_service.list_datasets(tenant_id=tenant_id, page=page, size=size)
+    return success_response(data=datasets, message="Listed datasets successfully")
 
 
 @evaluation_router.get("/{dataset_id}", response_model=ResponseModel[DatasetEntity])
+@handle_api_exceptions(action="get dataset")
 async def read_dataset(
     dataset_id: str,
     tenant_id: str = Depends(get_tenant_id),
@@ -70,19 +61,14 @@ async def read_dataset(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Reading dataset: {dataset_id} with tenant_id: {tenant_id}.")
-    try:
-        dataset_entity = await evaluation_service.get_dataset(dataset_id=dataset_id, tenant_id=tenant_id)
-        if not dataset_entity:
-            raise ApiException(code=404, message=f"Dataset '{dataset_id}' does not exist.")
-        return success_response(data=dataset_entity, message="Dataset retrieved successfully")
-    except ApiException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to read dataset: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Failed to retrieve dataset: '{e}'.")
+    dataset_entity = await evaluation_service.get_dataset(dataset_id=dataset_id, tenant_id=tenant_id)
+    if not dataset_entity:
+        raise ApiException(code=404, message=f"Dataset '{dataset_id}' does not exist.")
+    return success_response(data=dataset_entity, message="Dataset retrieved successfully")
 
 
 @evaluation_router.put("/{dataset_id}", response_model=ResponseModel[DatasetEntity])
+@handle_api_exceptions(action="update dataset")
 async def update_dataset(
     dataset_id: str,
     update_data: DatasetCreate,
@@ -91,19 +77,13 @@ async def update_dataset(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Updating dataset: {dataset_id} with tenant_id: {tenant_id}.")
-    try:
-        dataset_entity = await evaluation_service.update_dataset(dataset_id=dataset_id, update_data=update_data, tenant_id=tenant_id)
-        await session.refresh(dataset_entity)
-        return success_response(data=dataset_entity, message="Dataset updated successfully")
-    except ValueError as e:
-        logger.error(f"Failed to update dataset: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to update dataset: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Dataset update failed: '{e}'.")
+    dataset_entity = await evaluation_service.update_dataset(dataset_id=dataset_id, update_data=update_data, tenant_id=tenant_id)
+    await session.refresh(dataset_entity)
+    return success_response(data=dataset_entity, message="Dataset updated successfully")
 
 
 @evaluation_router.delete("/{dataset_id}")
+@handle_api_exceptions(action="delete dataset")
 async def delete_dataset(
     dataset_id: str,
     tenant_id: str = Depends(get_tenant_id),
@@ -111,21 +91,13 @@ async def delete_dataset(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Deleting dataset: {dataset_id} with tenant_id: {tenant_id}.")
-    try:
-        await evaluation_service.delete_dataset(dataset_id=dataset_id, tenant_id=tenant_id)
-        await session.commit()
-        return success_response(message="Dataset deleted successfully")
-    except ValueError as e:
-        logger.error(f"Failed to delete dataset: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete dataset: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=500, message=f"Dataset deletion failed: '{e}'.")
+    await evaluation_service.delete_dataset(dataset_id=dataset_id, tenant_id=tenant_id)
+    await session.commit()
+    return success_response(message="Dataset deleted successfully")
 
 
 @evaluation_router.post("/{dataset_id}/upload")
+@handle_api_exceptions(action="upload dataset samples", default_code=400)
 async def upload_dataset_samples(
     dataset_id: str,
     file: UploadFile = File(...),
@@ -137,31 +109,23 @@ async def upload_dataset_samples(
     if not file:
         raise ApiException(code=400, message="No file uploaded.")
 
-    try:
-        # Validate dataset exists
-        dataset = await evaluation_service.get_dataset(dataset_id=dataset_id, tenant_id=tenant_id)
-        if not dataset:
-            raise ApiException(code=404, message=f"Dataset '{dataset_id}' does not exist.")
+    # Validate dataset exists
+    dataset = await evaluation_service.get_dataset(dataset_id=dataset_id, tenant_id=tenant_id)
+    if not dataset:
+        raise ApiException(code=404, message=f"Dataset '{dataset_id}' does not exist.")
 
-        # Load data from file
-        file_results = await eval_client.load_dataset_from_upload_file(file=file)
+    # Load data from file
+    file_results = await eval_client.load_dataset_from_upload_file(file=file)
 
-        # Batch create dataset samples
-        dataset_entities = await evaluation_service.batch_create_dataset_samples(
-            dataset_id=dataset_id, samples=file_results, tenant_id=tenant_id
-        )
+    # Batch create dataset samples
+    dataset_entities = await evaluation_service.batch_create_dataset_samples(
+        dataset_id=dataset_id, samples=file_results, tenant_id=tenant_id
+    )
 
-        return success_response(data=dataset_entities, message="File uploaded successfully")
-    except ValueError as e:
-        logger.error(f"Failed to upload eval dataset: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to upload eval dataset: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=400, message=f"File upload failed: '{e}'.")
+    return success_response(data=dataset_entities, message="File uploaded successfully")
 
 @evaluation_router.get("/{dataset_id}/samples")
+@handle_api_exceptions(action="list dataset samples")
 async def list_dataset_samples(
     dataset_id: str,
     page: int = Query(default=1, ge=1),
@@ -170,18 +134,15 @@ async def list_dataset_samples(
     session: AsyncSession = Depends(get_db_session),
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
-    try:
-        samples = await evaluation_service.list_dataset_samples(dataset_id=dataset_id, tenant_id=tenant_id, page=page, size=size)
-        return success_response(data=samples, message="Listed dataset samples successfully")
-    except Exception as e:
-        logger.error(f"Failed to list dataset samples: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Listed dataset samples failed: '{e}'.")
+    samples = await evaluation_service.list_dataset_samples(dataset_id=dataset_id, tenant_id=tenant_id, page=page, size=size)
+    return success_response(data=samples, message="Listed dataset samples successfully")
 
 
 @evaluation_router.put(
     "/{dataset_id}/samples/{sample_id}",
     response_model=ResponseModel[DatasetSampleEntity],
 )
+@handle_api_exceptions(action="update dataset sample")
 async def update_dataset_sample(
     dataset_id: str,
     sample_id: str,
@@ -191,30 +152,22 @@ async def update_dataset_sample(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Updating dataset sample: {sample_id}.")
-    try:
-        dataset_sample_entity = await evaluation_service.update_dataset_sample(
-            sample_id=sample_id,
-            tenant_id=tenant_id,
-            input=new_sample.input,
-            expected_output=new_sample.expected_output,
-            eval_metadata=new_sample.eval_metadata,
-        )
-        await session.commit()
-        await session.refresh(dataset_sample_entity)
-        return success_response(data=dataset_sample_entity, message="Dataset sample updated successfully")
-    except ValueError as e:
-        logger.error(f"Failed to update dataset sample: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to update dataset sample: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=500, message=f"Dataset sample update failed: '{e}'.")
+    dataset_sample_entity = await evaluation_service.update_dataset_sample(
+        sample_id=sample_id,
+        tenant_id=tenant_id,
+        input=new_sample.input,
+        expected_output=new_sample.expected_output,
+        eval_metadata=new_sample.eval_metadata,
+    )
+    await session.commit()
+    await session.refresh(dataset_sample_entity)
+    return success_response(data=dataset_sample_entity, message="Dataset sample updated successfully")
 
 @evaluation_router.get(
     "/{dataset_id}/samples/{sample_id}",
     response_model=ResponseModel[DatasetSampleEntity],
 )
+@handle_api_exceptions(action="get dataset sample")
 async def get_dataset_sample(
     dataset_id: str,
     sample_id: str,
@@ -223,18 +176,13 @@ async def get_dataset_sample(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Getting dataset sample: {sample_id}.")
-    try:
-        dataset_sample_entity = await evaluation_service.get_dataset_sample(sample_id=sample_id, tenant_id=tenant_id)
-        if not dataset_sample_entity:
-            raise ApiException(code=404, message=f"Dataset sample '{sample_id}' does not exist.")
-        return success_response(data=dataset_sample_entity, message="Dataset sample retrieved successfully")
-    except ApiException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to get dataset sample: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Failed to retrieve dataset sample: '{e}'.")
+    dataset_sample_entity = await evaluation_service.get_dataset_sample(sample_id=sample_id, tenant_id=tenant_id)
+    if not dataset_sample_entity:
+        raise ApiException(code=404, message=f"Dataset sample '{sample_id}' does not exist.")
+    return success_response(data=dataset_sample_entity, message="Dataset sample retrieved successfully")
 
 @evaluation_router.delete("/{dataset_id}/samples/{sample_id}")
+@handle_api_exceptions(action="delete dataset sample")
 async def delete_dataset_sample(
     dataset_id: str,
     sample_id: str,
@@ -243,20 +191,12 @@ async def delete_dataset_sample(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Deleting dataset sample: {sample_id}.")
-    try:
-        await evaluation_service.delete_dataset_sample(sample_id=sample_id, tenant_id=tenant_id)
-        await session.commit()
-        return success_response(message="Dataset sample deleted successfully")
-    except ValueError as e:
-        logger.error(f"Failed to delete dataset sample: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete dataset sample: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=500, message=f"Dataset sample deletion failed: '{e}'.")
+    await evaluation_service.delete_dataset_sample(sample_id=sample_id, tenant_id=tenant_id)
+    await session.commit()
+    return success_response(message="Dataset sample deleted successfully")
 
 @evaluation_router.post("/{dataset_id}/experiments")
+@handle_api_exceptions(action="create experiment")
 async def create_experiment(
     dataset_id: str,
     experiment_create: ExperimentCreate,
@@ -268,32 +208,24 @@ async def create_experiment(
     if not experiment_create.sample_ids or len(experiment_create.sample_ids) == 0:
         raise ApiException(code=400, message="No sample IDs provided.")
 
-    try:
-        import app.worker as background_worker
+    import app.worker as background_worker
 
-        experiment_entity, exp_sample_ids = await evaluation_service.create_experiment(
-            dataset_id=dataset_id, experiment_data=experiment_create, tenant_id=tenant_id
-        )
-        await session.commit()
-        await session.refresh(experiment_entity)
+    experiment_entity, exp_sample_ids = await evaluation_service.create_experiment(
+        dataset_id=dataset_id, experiment_data=experiment_create, tenant_id=tenant_id
+    )
+    await session.commit()
+    await session.refresh(experiment_entity)
 
-        logger.info(f"Experiment {experiment_entity.id} created successfully.")
-        background_worker.execute_evaluation_task.delay(
-            dataset_id=dataset_id, experiment_id=experiment_entity.id, exp_run_ids=exp_sample_ids, tenant_id=tenant_id
-        )
+    logger.info(f"Experiment {experiment_entity.id} created successfully.")
+    background_worker.execute_evaluation_task.delay(
+        dataset_id=dataset_id, experiment_id=experiment_entity.id, exp_run_ids=exp_sample_ids, tenant_id=tenant_id
+    )
 
-        return success_response(data=experiment_entity, message="Experiment created successfully")
-    except ValueError as e:
-        logger.error(f"Failed to create experiment: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Experiment creation failed: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=500, message=f"Experiment creation failed: '{e}'.")
+    return success_response(data=experiment_entity, message="Experiment created successfully")
 
 
 @evaluation_router.get("/{dataset_id}/experiments")
+@handle_api_exceptions(action="list experiments")
 async def get_experiments(
     dataset_id: str,
     page: int = Query(default=1, ge=1),
@@ -303,15 +235,12 @@ async def get_experiments(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Get experiments for {dataset_id}.")
-    try:
-        experiments = await evaluation_service.list_experiments(dataset_id=dataset_id, tenant_id=tenant_id, page=page, size=size)
-        return success_response(data=experiments, message="Experiments listed successfully")
-    except Exception as e:
-        logger.error(f"Failed to get experiments: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Experiments listing failed: '{e}'.")
+    experiments = await evaluation_service.list_experiments(dataset_id=dataset_id, tenant_id=tenant_id, page=page, size=size)
+    return success_response(data=experiments, message="Experiments listed successfully")
 
 
 @evaluation_router.get("/{dataset_id}/experiments/{experiment_id}")
+@handle_api_exceptions(action="get experiment")
 async def get_experiment(
     dataset_id: str,
     experiment_id: str,
@@ -320,18 +249,13 @@ async def get_experiment(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Get experiment for dataset_id {dataset_id} and experiment_id {experiment_id}.")
-    try:
-        experiment_entity = await evaluation_service.get_experiment(experiment_id=experiment_id, tenant_id=tenant_id)
-        if not experiment_entity:
-            raise ApiException(code=404, message=f"Experiment '{experiment_id}' does not exist.")
-        return success_response(data=experiment_entity, message="Experiment retrieved successfully")
-    except ApiException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to get experiment: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Experiment retrieval failed: '{e}'.")
+    experiment_entity = await evaluation_service.get_experiment(experiment_id=experiment_id, tenant_id=tenant_id)
+    if not experiment_entity:
+        raise ApiException(code=404, message=f"Experiment '{experiment_id}' does not exist.")
+    return success_response(data=experiment_entity, message="Experiment retrieved successfully")
 
 @evaluation_router.get("/{dataset_id}/experiments/{experiment_id}/samples")
+@handle_api_exceptions(action="list experiment samples")
 async def get_experiment_samples(
     dataset_id: str,
     experiment_id: str,
@@ -343,14 +267,11 @@ async def get_experiment_samples(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Get experiment details for dataset_id {dataset_id}, experiment_id {experiment_id}, status={status}.")
-    try:
-        experiment_samples = await evaluation_service.get_experiment_samples(experiment_id=experiment_id, tenant_id=tenant_id, page=page, size=size, status=status)
-        return success_response(data=experiment_samples, message="Experiment samples listed successfully")
-    except Exception as e:
-        logger.error(f"Failed to get experiment samples: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Experiment samples listing failed: '{e}'.")
+    experiment_samples = await evaluation_service.get_experiment_samples(experiment_id=experiment_id, tenant_id=tenant_id, page=page, size=size, status=status)
+    return success_response(data=experiment_samples, message="Experiment samples listed successfully")
 
 @evaluation_router.put("/{dataset_id}/experiments/{experiment_id}/samples")
+@handle_api_exceptions(action="evaluate experiment sample")
 async def evaluate_experiment_sample(
     dataset_id: str,
     experiment_id: str,
@@ -360,22 +281,16 @@ async def evaluate_experiment_sample(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"evaluate_single_sample for dataset_id: {dataset_id}, experiment_id: {experiment_id}, exp_run_id: {experiment_sample_entity.id}")
-    try:
-        import app.worker as background_worker
+    import app.worker as background_worker
 
-        logger.info(f"Re-evaluating sample {experiment_sample_entity.id} successful.")
-        background_worker.execute_evaluation_task.delay(
-            dataset_id=dataset_id, experiment_id=experiment_id, exp_run_ids=[experiment_sample_entity.id], tenant_id=tenant_id
-        )
-        return success_response(message="Re-evaluation of the sample started successfully.")
-    except ValueError as e:
-        logger.error(f"Failed to evaluate experiment sample: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to evaluate experiment sample: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Re-evaluation of the sample failed: '{e}'.")
+    logger.info(f"Re-evaluating sample {experiment_sample_entity.id} successful.")
+    background_worker.execute_evaluation_task.delay(
+        dataset_id=dataset_id, experiment_id=experiment_id, exp_run_ids=[experiment_sample_entity.id], tenant_id=tenant_id
+    )
+    return success_response(message="Re-evaluation of the sample started successfully.")
 
 @evaluation_router.delete("/{dataset_id}/experiments/{experiment_id}")
+@handle_api_exceptions(action="delete experiment")
 async def delete_experiment(
     dataset_id: str,
     experiment_id: str,
@@ -384,21 +299,13 @@ async def delete_experiment(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Delete experiment for dataset_id {dataset_id} and experiment_id {experiment_id}.")
-    try:
-        await evaluation_service.delete_experiment(experiment_id=experiment_id, tenant_id=tenant_id)
-        await session.commit()
-        return success_response(message="Experiment deleted successfully")
-    except ValueError as e:
-        logger.error(f"Failed to delete experiment: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete experiment: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=500, message=f"Experiment deletion failed: '{e}'.")
+    await evaluation_service.delete_experiment(experiment_id=experiment_id, tenant_id=tenant_id)
+    await session.commit()
+    return success_response(message="Experiment deleted successfully")
 
 
 @evaluation_router.post("/{dataset_id}/runconfigs")
+@handle_api_exceptions(action="create run config", default_code=400)
 async def create_run_config(
     dataset_id: str,
     config_data: RunConfigCreate,
@@ -407,25 +314,17 @@ async def create_run_config(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info("Create run_config.")
-    try:
-        run_config_entity = await evaluation_service.create_run_config(dataset_id=dataset_id, config_data=config_data, tenant_id=tenant_id)
-        await session.refresh(run_config_entity)
+    run_config_entity = await evaluation_service.create_run_config(dataset_id=dataset_id, config_data=config_data, tenant_id=tenant_id)
+    await session.refresh(run_config_entity)
 
-        logger.info(f"Run config {run_config_entity.id} created successfully.")
-        return success_response(data=run_config_entity, message="Run config created successfully")
-    except ValueError as e:
-        logger.error(f"Failed to create run config: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create run config: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=400, message=f"Failed to create run config: {e}")
+    logger.info(f"Run config {run_config_entity.id} created successfully.")
+    return success_response(data=run_config_entity, message="Run config created successfully")
 
 
 @evaluation_router.put(
     "/{dataset_id}/runconfigs/{config_id}", response_model=ResponseModel[RunConfigEntity]
 )
+@handle_api_exceptions(action="update run config")
 async def update_run_config(
     dataset_id: str,
     config_id: str,
@@ -434,24 +333,14 @@ async def update_run_config(
     session: AsyncSession = Depends(get_db_session),
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
-    try:
-        run_config = await evaluation_service.update_run_config(config_id=config_id, update_data=update_data, tenant_id=tenant_id)
-        await session.refresh(run_config)
+    run_config = await evaluation_service.update_run_config(config_id=config_id, update_data=update_data, tenant_id=tenant_id)
+    await session.refresh(run_config)
 
-        return success_response(data=run_config, message="Run config updated successfully")
-    except ValueError as e:
-        logger.error(f"Failed to update run config {config_id}: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(
-            f"Failed to update run config {config_id}: {traceback.format_exc()}"
-        )
-        await session.rollback()
-        raise ApiException(code=500, message=f"Run config update failed: {str(e)}")
+    return success_response(data=run_config, message="Run config updated successfully")
 
 
 @evaluation_router.get("/{dataset_id}/runconfigs")
+@handle_api_exceptions(action="list run configs")
 async def list_run_configs(
     dataset_id: str,
     page: int = Query(default=1, ge=1),
@@ -461,15 +350,12 @@ async def list_run_configs(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Get run_configs for {dataset_id}.")
-    try:
-        run_configs = await evaluation_service.list_run_configs(dataset_id=dataset_id, tenant_id=tenant_id, page=page, size=size)
-        return success_response(data=run_configs, message="Run configs listed successfully")
-    except Exception as e:
-        logger.error(f"Failed to list run configs: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Fail to list run configs: '{e}'.")
+    run_configs = await evaluation_service.list_run_configs(dataset_id=dataset_id, tenant_id=tenant_id, page=page, size=size)
+    return success_response(data=run_configs, message="Run configs listed successfully")
 
 
 @evaluation_router.get("/{dataset_id}/runconfigs/{config_id}")
+@handle_api_exceptions(action="get run config")
 async def get_config_details(
     dataset_id: str,
     config_id: str,
@@ -478,17 +364,14 @@ async def get_config_details(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Get experiment for config_id {config_id}.")
-    try:
-        run_config = await evaluation_service.get_run_config(config_id=config_id, tenant_id=tenant_id)
-        if not run_config:
-            raise ApiException(code=404, message=f"Run config '{config_id}' does not exist.")
-        return success_response(data=run_config, message="Run config retrieved successfully")
-    except Exception as e:
-        logger.error(f"Failed to get run config: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Fail to get run config: '{e}'.")
+    run_config = await evaluation_service.get_run_config(config_id=config_id, tenant_id=tenant_id)
+    if not run_config:
+        raise ApiException(code=404, message=f"Run config '{config_id}' does not exist.")
+    return success_response(data=run_config, message="Run config retrieved successfully")
 
 
 @evaluation_router.delete("/{dataset_id}/runconfigs/{config_id}")
+@handle_api_exceptions(action="delete run config")
 async def delete_config(
     dataset_id: str,
     config_id: str,
@@ -497,23 +380,15 @@ async def delete_config(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Delete experiment for config_id {config_id}.")
-    try:
-        await evaluation_service.delete_run_config(config_id=config_id, tenant_id=tenant_id)
-        await session.commit()
-        logger.info(f"run_config {config_id} has been deleted.")
-        return success_response(message=f"Run config '{config_id}' deleted successfully.")
-    except ValueError as e:
-        logger.error(f"Failed to delete run config: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete run config: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=500, message=f"Run config deletion failed: '{e}'.")
+    await evaluation_service.delete_run_config(config_id=config_id, tenant_id=tenant_id)
+    await session.commit()
+    logger.info(f"run_config {config_id} has been deleted.")
+    return success_response(message=f"Run config '{config_id}' deleted successfully.")
 
 
 
 @evaluation_router.post("/{dataset_id}/evalconfigs")
+@handle_api_exceptions(action="create eval config", default_code=400)
 async def create_evaluator_config(
     dataset_id: str,
     config_data: EvaluatorConfigCreate,
@@ -522,26 +397,18 @@ async def create_evaluator_config(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info("Create eval_config_entity.")
-    try:
-        eval_config_entity = await evaluation_service.create_evaluator_config(
-            dataset_id=dataset_id, config_data=config_data, tenant_id=tenant_id
-        )
-        await session.refresh(eval_config_entity)
-        logger.info(f"Eval config {eval_config_entity.id} created successfully.")
-        return success_response(data=eval_config_entity, message="Eval config created successfully")
-    except ValueError as e:
-        logger.error(f"Failed to create eval config: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create eval config: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=400, message=f"Failed to create eval config: {e}")
+    eval_config_entity = await evaluation_service.create_evaluator_config(
+        dataset_id=dataset_id, config_data=config_data, tenant_id=tenant_id
+    )
+    await session.refresh(eval_config_entity)
+    logger.info(f"Eval config {eval_config_entity.id} created successfully.")
+    return success_response(data=eval_config_entity, message="Eval config created successfully")
 
 
 @evaluation_router.put(
     "/{dataset_id}/evalconfigs/{config_id}", response_model=ResponseModel[EvaluatorConfigEntity]
 )
+@handle_api_exceptions(action="update eval config")
 async def update_evaluator_config(
     dataset_id: str,
     config_id: str,
@@ -550,26 +417,16 @@ async def update_evaluator_config(
     session: AsyncSession = Depends(get_db_session),
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
-    try:
-        eval_config = await evaluation_service.update_evaluator_config(
-            config_id=config_id, update_data=update_data, tenant_id=tenant_id
-        )
-        await session.refresh(eval_config)
+    eval_config = await evaluation_service.update_evaluator_config(
+        config_id=config_id, update_data=update_data, tenant_id=tenant_id
+    )
+    await session.refresh(eval_config)
 
-        return success_response(data=eval_config, message="Eval config updated successfully")
-    except ValueError as e:
-        logger.error(f"Failed to update evaluator config {config_id}: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(
-            f"Failed to update evaluator config {config_id}: {traceback.format_exc()}"
-        )
-        await session.rollback()
-        raise ApiException(code=500, message=f"Eval config update failed: {str(e)}")
+    return success_response(data=eval_config, message="Eval config updated successfully")
 
 
 @evaluation_router.get("/{dataset_id}/evalconfigs")
+@handle_api_exceptions(action="list eval configs")
 async def list_eval_configs(
     dataset_id: str,
     page: int = Query(default=1, ge=1),
@@ -579,17 +436,14 @@ async def list_eval_configs(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Get eval configs for {dataset_id}.")
-    try:
-        eval_configs = await evaluation_service.list_evaluator_configs(
-            dataset_id=dataset_id, tenant_id=tenant_id, page=page, size=size
-        )
-        return success_response(data=eval_configs, message="Eval configs listed successfully")
-    except Exception as e:
-        logger.error(f"Failed to list evaluator configs: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Fail to list eval configs: '{e}'.")
+    eval_configs = await evaluation_service.list_evaluator_configs(
+        dataset_id=dataset_id, tenant_id=tenant_id, page=page, size=size
+    )
+    return success_response(data=eval_configs, message="Eval configs listed successfully")
 
 
 @evaluation_router.get("/{dataset_id}/evalconfigs/{config_id}")
+@handle_api_exceptions(action="get eval config")
 async def get_eval_config_details(
     dataset_id: str,
     config_id: str,
@@ -598,17 +452,14 @@ async def get_eval_config_details(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Get evalconfigs for config_id {config_id}.")
-    try:
-        eval_config = await evaluation_service.get_evaluator_config(config_id=config_id, tenant_id=tenant_id)
-        if not eval_config:
-            raise ApiException(code=404, message=f"Eval config '{config_id}' does not exist.")
-        return success_response(data=eval_config, message="Eval config retrieved successfully")
-    except Exception as e:
-        logger.error(f"Failed to get evaluator config: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Fail to get eval config: '{e}'.")
+    eval_config = await evaluation_service.get_evaluator_config(config_id=config_id, tenant_id=tenant_id)
+    if not eval_config:
+        raise ApiException(code=404, message=f"Eval config '{config_id}' does not exist.")
+    return success_response(data=eval_config, message="Eval config retrieved successfully")
 
 
 @evaluation_router.delete("/{dataset_id}/evalconfigs/{config_id}")
+@handle_api_exceptions(action="delete eval config")
 async def delete_eval_config(
     dataset_id: str,
     config_id: str,
@@ -617,16 +468,7 @@ async def delete_eval_config(
     evaluation_service: EvaluationService = Depends(get_evaluation_service),
 ):
     logger.info(f"Delete experiment for config_id {config_id}.")
-    try:
-        await evaluation_service.delete_evaluator_config(config_id)
-        await session.commit()
-        logger.info(f"eval_config {config_id} has been deleted.")
-        return success_response(message=f"Eval config '{config_id}' deleted successfully.")
-    except ValueError as e:
-        logger.error(f"Failed to delete evaluator config: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete evaluator config: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=500, message=f"Eval config deletion failed: '{e}'.")
+    await evaluation_service.delete_evaluator_config(config_id)
+    await session.commit()
+    logger.info(f"eval_config {config_id} has been deleted.")
+    return success_response(message=f"Eval config '{config_id}' deleted successfully.")

--- a/backend/api/v1/config_apis/knowledgebase.py
+++ b/backend/api/v1/config_apis/knowledgebase.py
@@ -19,7 +19,7 @@ from pairag.file.nodeparsers.file_parser import ChunkConfig
 from db.db_context import get_db_session
 from pairag.file.store.file_store_helper import file_store
 from common.chat.response_model import ResponseModel, success_response
-from api.api_exception import ApiException
+from api.api_exception import ApiException, handle_api_exceptions
 from service.injection import get_rag_service, get_file_service, get_chunk_service, get_tenant_id, get_knowledgebase_service
 from service.knowledgebase.rag_service import RagService
 from service.knowledgebase.file_service import FileService
@@ -34,21 +34,18 @@ knowledgebase_router = APIRouter()
 
 
 @knowledgebase_router.delete("/metadata-schema-cache")
+@handle_api_exceptions(action="clear metadata schema cache")
 async def clear_metadata_schema_cache(
     tenant_id: str = Depends(get_tenant_id),
 ):
     """Clear metadata schema cache for the current tenant.
     The background task will automatically repopulate the cache."""
-    try:
-        from service.cache.metadata_schema_cache import metadata_schema_cache
-        count = await metadata_schema_cache.clear_cache_by_tenant(tenant_id)
-        return success_response(
-            data={"cleared": count},
-            message="Metadata schema cache cleared.",
-        )
-    except Exception as e:
-        logger.error(f"Failed to clear metadata schema cache: {e}")
-        raise ApiException(code=500, message=f"Failed to clear metadata schema cache: {e}")
+    from service.cache.metadata_schema_cache import metadata_schema_cache
+    count = await metadata_schema_cache.clear_cache_by_tenant(tenant_id)
+    return success_response(
+        data={"cleared": count},
+        message="Metadata schema cache cleared.",
+    )
 
 
 @knowledgebase_router.post("", response_model=ResponseModel[KbEntity])
@@ -81,6 +78,7 @@ async def create_knowledgebase(
         raise ApiException(code=400, message=i18n.t("api.knowledgebase.create_failed", error=str(e)))
 
 @knowledgebase_router.get("")
+@handle_api_exceptions(action="list knowledgebases", i18n_error_key="api.knowledgebase.list_failed", default_code=400)
 async def list_knowledgebases(
     page: int = Query(default=1, ge=1),
     size: int = Query(default=10, le=1000),
@@ -91,42 +89,26 @@ async def list_knowledgebases(
     rag_service: RagService = Depends(get_rag_service),
     knowledgebase_service: KnowledgebaseService = Depends(get_knowledgebase_service),
 ):
-    try:
-        if not ids:
-            paged_result = await rag_service.list_knowledgebases(tenant_id=tenant_id, page=page, size=size, query=query)
-            return success_response(data=paged_result, message=i18n.t("api.knowledgebase.list_success"))
-        else:
-            kb_ids = parse_comma_separated_list(ids)
-            total_result = await knowledgebase_service.get_knowledgebases_by_ids(tenant_id=tenant_id, kb_ids=kb_ids)
-            return success_response(data=total_result, message=i18n.t("api.knowledgebase.list_success"))
-    except ValueError as e:
-        logger.error(f"Failed to list knowledge bases.\nValueError:{e}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to list knowledge bases.\nException:{traceback.format_exc()}")
-        raise ApiException(code=400, message=i18n.t("api.knowledgebase.list_failed", error=str(e)))
+    if not ids:
+        paged_result = await rag_service.list_knowledgebases(tenant_id=tenant_id, page=page, size=size, query=query)
+        return success_response(data=paged_result, message=i18n.t("api.knowledgebase.list_success"))
+    kb_ids = parse_comma_separated_list(ids)
+    total_result = await knowledgebase_service.get_knowledgebases_by_ids(tenant_id=tenant_id, kb_ids=kb_ids)
+    return success_response(data=total_result, message=i18n.t("api.knowledgebase.list_success"))
 
 
 @knowledgebase_router.get("/{kb_id}", response_model=ResponseModel[KbEntity])
+@handle_api_exceptions(action="query knowledgebase", i18n_error_key="api.knowledgebase.query_failed", default_code=400)
 async def read_knowledgebase(
     kb_id: str,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        knowledgebase = await rag_service.get_knowledgebase(kb_id=kb_id, tenant_id=tenant_id)
-        if not knowledgebase:
-            raise ApiException.not_found(kb_id, "Knowledgebase")
-        return success_response(data=knowledgebase, message=i18n.t("api.knowledgebase.query_success"))
-    except ApiException:
-        raise
-    except ValueError as e:
-        logger.error(f"Failed to query knowledge base.\nValueError:{e}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to query knowledge base.\nException:{traceback.format_exc()}")
-        raise ApiException(code=400, message=i18n.t("api.knowledgebase.query_failed", error=str(e)))
+    knowledgebase = await rag_service.get_knowledgebase(kb_id=kb_id, tenant_id=tenant_id)
+    if not knowledgebase:
+        raise ApiException.not_found(kb_id, "Knowledgebase")
+    return success_response(data=knowledgebase, message=i18n.t("api.knowledgebase.query_success"))
 
 
 @knowledgebase_router.put("/{kb_id}", response_model=ResponseModel[KbEntity])
@@ -191,24 +173,18 @@ async def update_knowledgebase(
         ))
 
 @knowledgebase_router.delete("/{kb_id}")
+@handle_api_exceptions(action="delete knowledgebase", default_code=400)
 async def delete_knowledgebase(
     kb_id: str,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        await rag_service.delete_knowledgebase(kb_id=kb_id, tenant_id=tenant_id)
-
-        return success_response(data=None, message=i18n.t("api.knowledgebase.delete_success"))
-    except ValueError as e:
-        logger.error(f"Failed to delete knowledge base.\nValueError:{e}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete knowledge base.\nException:{traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Failed to delete knowledge base: {e}.")
+    await rag_service.delete_knowledgebase(kb_id=kb_id, tenant_id=tenant_id)
+    return success_response(data=None, message=i18n.t("api.knowledgebase.delete_success"))
 
 @knowledgebase_router.get("/{kb_id}/files")
+@handle_api_exceptions(action="list files", default_code=400)
 async def list_files(
     kb_id: str,
     file_name: Optional[str] = None,
@@ -220,21 +196,13 @@ async def list_files(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        if file_name:
-            file_entity = await rag_service.get_file_by_name(kb_id=kb_id, file_name=file_name, tenant_id=tenant_id)
-            if not file_entity:
-                raise ApiException.not_found(file_name, i18n.t("api.knowledgebase.file_resource_name"))
-            return success_response(data=file_entity, message=i18n.t("api.knowledgebase.file_query_success"))
-        else:
-            page_result = await rag_service.list_files(kb_id=kb_id, tenant_id=tenant_id, page=page, size=size, query=query, status=status)
-            return success_response(data=page_result, message=i18n.t("api.knowledgebase.file_list_success"))
-    except ValueError as e:
-        logger.error(f"Failed to query file.\nValueError:{e}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to query file.\nException:{traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Failed to query file: {e}.")
+    if file_name:
+        file_entity = await rag_service.get_file_by_name(kb_id=kb_id, file_name=file_name, tenant_id=tenant_id)
+        if not file_entity:
+            raise ApiException.not_found(file_name, i18n.t("api.knowledgebase.file_resource_name"))
+        return success_response(data=file_entity, message=i18n.t("api.knowledgebase.file_query_success"))
+    page_result = await rag_service.list_files(kb_id=kb_id, tenant_id=tenant_id, page=page, size=size, query=query, status=status)
+    return success_response(data=page_result, message=i18n.t("api.knowledgebase.file_list_success"))
 
 
 
@@ -413,6 +381,7 @@ async def upload_files(
 @knowledgebase_router.get(
     "/{kb_id}/files/{file_id}", response_model=ResponseModel[KbFileEntity]
 )
+@handle_api_exceptions(action="get file", default_code=400)
 async def get_kb_file(
     kb_id: str,
     file_id: str,
@@ -420,20 +389,13 @@ async def get_kb_file(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        file_entity = await rag_service.get_file(kb_id=kb_id, file_id=file_id, tenant_id=tenant_id)
-        if not file_entity:
-            raise ApiException.not_found(file_id, "File")
+    file_entity = await rag_service.get_file(kb_id=kb_id, file_id=file_id, tenant_id=tenant_id)
+    if not file_entity:
+        raise ApiException.not_found(file_id, "File")
 
-        file_url = await file_store.get_url_async(file_path=file_entity.file_path, tenant_id=tenant_id)
-        file_entity.file_metadata["file_url"] = file_url
-        return success_response(data=file_entity, message="File query successful")
-    except ValueError as e:
-        logger.error(f"File query failed.\nValueError:{e}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"File query failed.\nException:{traceback.format_exc()}")
-        raise ApiException(code=400, message=f"File query failed: {e}.")
+    file_url = await file_store.get_url_async(file_path=file_entity.file_path, tenant_id=tenant_id)
+    file_entity.file_metadata["file_url"] = file_url
+    return success_response(data=file_entity, message="File query successful")
 
 
 class ReprocessFileRequest(BaseModel):
@@ -441,6 +403,7 @@ class ReprocessFileRequest(BaseModel):
 
 
 @knowledgebase_router.put("/{kb_id}/files/{file_id}")
+@handle_api_exceptions(action="reprocess file", default_code=400)
 async def reprocess_file(
     kb_id: str,
     file_id: str,
@@ -450,39 +413,31 @@ async def reprocess_file(
     file_service: FileService = Depends(get_file_service),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        file_entities = await file_service.get_files_by_ids(file_ids=[file_id], tenant_id=tenant_id)
-        if not file_entities:
-            raise ApiException.not_found(file_id, "File")
+    file_entities = await file_service.get_files_by_ids(file_ids=[file_id], tenant_id=tenant_id)
+    if not file_entities:
+        raise ApiException.not_found(file_id, "File")
 
-        # 如果提供了 chunk_config，先验证并更新
-        chunk_config = None
-        if body and body.chunk_config:
-            try:
-                ChunkConfig.model_validate(body.chunk_config)
-                chunk_config = body.chunk_config
-            except Exception as e:
-                raise ApiException(code=400, message=f"chunk_config format is incorrect: {e}")
+    # 如果提供了 chunk_config，先验证并更新
+    chunk_config = None
+    if body and body.chunk_config:
+        try:
+            ChunkConfig.model_validate(body.chunk_config)
+            chunk_config = body.chunk_config
+        except Exception as e:
+            raise ApiException(code=400, message=f"chunk_config format is incorrect: {e}")
 
-        reprocessed_count = await _batch_reprocess_files(
-            kb_id=kb_id,
-            file_entities=file_entities,
-            session=session,
-            tenant_id=tenant_id,
-            chunk_config=chunk_config
-        )
-        return success_response(data=reprocessed_count, message=f"Successfully added {reprocessed_count} files to the reprocessing queue.")
-    except ApiException:
-        raise
-    except ValueError as e:
-        logger.error(f"Reprocess file failed.\nValueError:{e}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Reprocess file failed.\nException:{traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Reprocess file failed: {e}.")
+    reprocessed_count = await _batch_reprocess_files(
+        kb_id=kb_id,
+        file_entities=file_entities,
+        session=session,
+        tenant_id=tenant_id,
+        chunk_config=chunk_config
+    )
+    return success_response(data=reprocessed_count, message=f"Successfully added {reprocessed_count} files to the reprocessing queue.")
 
 
 @knowledgebase_router.delete("/{kb_id}/files/{file_id}")
+@handle_api_exceptions(action="delete file", default_code=400)
 async def delete_file(
     kb_id: str,
     file_id: str,
@@ -490,15 +445,8 @@ async def delete_file(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        await rag_service.delete_file(kb_id=kb_id, file_id=file_id, tenant_id=tenant_id)
-        return success_response(data=None, message="File deletion successful.")
-    except ValueError as e:
-        logger.error(f"File deletion failed.\nValueError:{e}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"File deletion failed.\nException:{traceback.format_exc()}")
-        raise ApiException(code=400, message=f"File deletion failed: {e}.")
+    await rag_service.delete_file(kb_id=kb_id, file_id=file_id, tenant_id=tenant_id)
+    return success_response(data=None, message="File deletion successful.")
 
 
 class BatchOperationRequest(BaseModel):
@@ -659,6 +607,7 @@ async def set_file_source(
 
 
 @knowledgebase_router.get("/{kb_id}/files/{file_id}/chunks")
+@handle_api_exceptions(action="list chunks", default_code=500)
 async def list_chunks(
     kb_id: str,
     file_id: str,
@@ -668,16 +617,12 @@ async def list_chunks(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        chunk_entities = await rag_service.list_chunks(kb_id=kb_id, file_id=file_id, tenant_id=tenant_id, page=page, size=size)
-
-        return success_response(data=chunk_entities, message="Chunk list retrieval successful")
-    except Exception as e:
-        logger.error(f"Failed to list chunks for knowledgebase {kb_id} / file {file_id}: {e}")
-        raise ApiException(code=500, message=f"List chunks failed: {e}")
+    chunk_entities = await rag_service.list_chunks(kb_id=kb_id, file_id=file_id, tenant_id=tenant_id, page=page, size=size)
+    return success_response(data=chunk_entities, message="Chunk list retrieval successful")
 
 
 @knowledgebase_router.put("/{kb_id}/files/{file_id}/chunks/{chunk_id}", response_model=ResponseModel[KbChunkEntity])
+@handle_api_exceptions(action="update chunk", default_code=500)
 async def update_chunk(
     kb_id: str,
     file_id: str,
@@ -687,12 +632,8 @@ async def update_chunk(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        kb_chunk = await rag_service.update_chunk(kb_id=kb_id, file_id=file_id, chunk_id=chunk_id, chunk=update_kb_chunk, tenant_id=tenant_id)
-        return success_response(data=kb_chunk, message="Chunk update successful")
-    except Exception as ex:
-        logger.error(f"Failed to update knowledgebase {kb_id} / file {file_id} / chunk {chunk_id}: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Chunk update failed: {str(ex)}")
+    kb_chunk = await rag_service.update_chunk(kb_id=kb_id, file_id=file_id, chunk_id=chunk_id, chunk=update_kb_chunk, tenant_id=tenant_id)
+    return success_response(data=kb_chunk, message="Chunk update successful")
 
 
 class AddChunkRequest(BaseModel):
@@ -700,6 +641,7 @@ class AddChunkRequest(BaseModel):
     chunk_metadata: dict = Field(default={}, description="Chunk metadata")
 
 @knowledgebase_router.delete("/{kb_id}/files/{file_id}/chunks/{chunk_id}")
+@handle_api_exceptions(action="delete chunk", default_code=500)
 async def delete_chunk(
     kb_id: str,
     file_id: str,
@@ -708,14 +650,11 @@ async def delete_chunk(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        await rag_service.delete_chunk(chunk_id=chunk_id, kb_id=kb_id, file_id=file_id, tenant_id=tenant_id)
-        return success_response(data=None, message="Chunk deletion successful.")
-    except Exception as ex:
-        logger.error(f"Failed to delete chunk from knowledgebase {kb_id} / file {file_id} / chunk {chunk_id}: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Chunk deletion failed: {str(ex)}")
+    await rag_service.delete_chunk(chunk_id=chunk_id, kb_id=kb_id, file_id=file_id, tenant_id=tenant_id)
+    return success_response(data=None, message="Chunk deletion successful.")
 
 @knowledgebase_router.post("/{kb_id}/files/{file_id}/chunks", response_model=ResponseModel[KbChunkEntity])
+@handle_api_exceptions(action="add chunk", default_code=500)
 async def add_chunk(
     kb_id: str,
     file_id: str,
@@ -733,10 +672,5 @@ async def add_chunk(
     - chunk_index: Automatically set to max(index) + 1 for the file
     - chunk_metadata: Combines file_metadata + token_count
     """
-    try:
-        new_chunk = await rag_service.add_chunk(kb_id=kb_id, file_id=file_id, text=request.text, chunk_metadata=request.chunk_metadata, tenant_id=tenant_id)
-
-        return success_response(data=new_chunk, message="Chunk addition successful.")
-    except Exception as ex:
-        logger.exception(f"Failed to add chunk to knowledgebase {kb_id} / file {file_id}: {ex}")
-        raise ApiException(code=500, message=f"Chunk addition failed: {str(ex)}")
+    new_chunk = await rag_service.add_chunk(kb_id=kb_id, file_id=file_id, text=request.text, chunk_metadata=request.chunk_metadata, tenant_id=tenant_id)
+    return success_response(data=new_chunk, message="Chunk addition successful.")

--- a/backend/api/v1/config_apis/metadata.py
+++ b/backend/api/v1/config_apis/metadata.py
@@ -1,16 +1,13 @@
 ### Knowledgebase configuration API ###
-import traceback
 from typing import List
 from fastapi import Depends, Query
 from sqlmodel.ext.asyncio.session import AsyncSession
 from db.models.knowledgebase.file import KbFileEntity, MetadataEntryData
 from db.db_context import get_db_session
-from sqlalchemy.exc import IntegrityError
 from db.models.knowledgebase.metadata import KbMetadataEntity, KbMetadataEntityCreate
 from common.chat.response_model import ResponseModel, success_response
-from api.api_exception import ApiException
+from api.api_exception import handle_api_exceptions
 from api.v1.config_apis.knowledgebase import knowledgebase_router
-from loguru import logger
 from service.knowledgebase.rag_service import RagService
 from service.knowledgebase.metadata_service import MetadataService
 from service.injection import get_rag_service, get_metadata_service, get_tenant_id
@@ -18,6 +15,7 @@ from service.injection import get_rag_service, get_metadata_service, get_tenant_
 
 
 @knowledgebase_router.post("/{kb_id}/metadata", response_model=ResponseModel[KbMetadataEntity])
+@handle_api_exceptions(action="create metadata")
 async def add_kb_metadata(
     kb_id: str,
     metadata_create: KbMetadataEntityCreate,
@@ -26,19 +24,12 @@ async def add_kb_metadata(
     rag_service: RagService = Depends(get_rag_service),
     metadata_service: MetadataService = Depends(get_metadata_service),
 ):
-    try:
-        metadata_entity = await metadata_service.create_metadata(kb_id=kb_id, metadata_create=metadata_create, tenant_id=tenant_id)
-        return success_response(data=metadata_entity, message="Metadata created successfully.")
-
-    except IntegrityError as e:
-        logger.error(f"Failed to add metadata. Exception:{traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Create metadata failed: '{e}'.")
-    except Exception as e:
-        logger.error(f"Failed to add metadata. Exception:{traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Create metadata failed: '{e}'.")
+    metadata_entity = await metadata_service.create_metadata(kb_id=kb_id, metadata_create=metadata_create, tenant_id=tenant_id)
+    return success_response(data=metadata_entity, message="Metadata created successfully.")
 
 
 @knowledgebase_router.get("/{kb_id}/metadata", response_model=ResponseModel[List[dict]])
+@handle_api_exceptions(action="list metadata")
 async def list_metadata(
     kb_id: str,
     page: int = Query(default=1, ge=1),
@@ -47,15 +38,12 @@ async def list_metadata(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        metadata_list = await rag_service.list_metadata(kb_id=kb_id, tenant_id=tenant_id, page=page, size=size)
-        return success_response(data=metadata_list, message="List metadata success.")
-    except Exception as e:
-        logger.exception(f"List metadata failed. \nException:{traceback.format_exc()}")
-        raise ApiException(code=500, message=f"List metadata failed: {e}.")
+    metadata_list = await rag_service.list_metadata(kb_id=kb_id, tenant_id=tenant_id, page=page, size=size)
+    return success_response(data=metadata_list, message="List metadata success.")
 
 
 @knowledgebase_router.put("/{kb_id}/metadata/{metadata_id}", response_model=ResponseModel[List[KbMetadataEntity]])
+@handle_api_exceptions(action="update metadata")
 async def update_metadata(
     kb_id: str,
     metadata_id: str,
@@ -64,19 +52,16 @@ async def update_metadata(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        metadata_entity = await rag_service.update_metadata(
-            kb_id=kb_id,
-            metadata_id=metadata_id,
-            update_data=new_metadata_entity,
-            tenant_id=tenant_id)
-        return success_response(data=metadata_entity, message="Update metadata success.")
-    except Exception as e:
-        logger.exception(f"Update metadata failed. \nException:{traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Update metadata failed: {e}.")
+    metadata_entity = await rag_service.update_metadata(
+        kb_id=kb_id,
+        metadata_id=metadata_id,
+        update_data=new_metadata_entity,
+        tenant_id=tenant_id)
+    return success_response(data=metadata_entity, message="Update metadata success.")
 
 
 @knowledgebase_router.delete("/{kb_id}/metadata/{metadata_id}", response_model=ResponseModel[KbMetadataEntity])
+@handle_api_exceptions(action="delete metadata")
 async def delete_metadata(
     kb_id: str,
     metadata_id: str,
@@ -84,15 +69,12 @@ async def delete_metadata(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        metadata_entity = await rag_service.delete_metadata(kb_id=kb_id, metadata_id=metadata_id, tenant_id=tenant_id)
-        return success_response(data=metadata_entity, message="Delete metadata success.")
-    except Exception as e:
-        logger.exception(f"Delete metadata failed. \nException:{traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Delete metadata failed: {e}.")
+    metadata_entity = await rag_service.delete_metadata(kb_id=kb_id, metadata_id=metadata_id, tenant_id=tenant_id)
+    return success_response(data=metadata_entity, message="Delete metadata success.")
 
 
 @knowledgebase_router.post("/{kb_id}/files/{file_id}/metadata", response_model=ResponseModel[KbFileEntity])
+@handle_api_exceptions(action="set file metadata")
 async def set_file_metadata(
     kb_id: str,
     file_id: str,
@@ -101,9 +83,5 @@ async def set_file_metadata(
     session: AsyncSession = Depends(get_db_session),
     rag_service: RagService = Depends(get_rag_service),
 ):
-    try:
-        file_entity = await rag_service.set_file_metadata(kb_id=kb_id, file_id=file_id, entry_data=entry_data, tenant_id=tenant_id)
-        return success_response(data=file_entity, message="Set file metadata success.")
-    except Exception as e:
-        logger.exception(f"Set file metadata failed. \nException:{traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Set file metadata failed: {e}.")
+    file_entity = await rag_service.set_file_metadata(kb_id=kb_id, file_id=file_id, entry_data=entry_data, tenant_id=tenant_id)
+    return success_response(data=file_entity, message="Set file metadata success.")

--- a/backend/api/v1/config_apis/role/role.py
+++ b/backend/api/v1/config_apis/role/role.py
@@ -1,6 +1,5 @@
 ### Role configuration API ###
 
-import traceback
 from typing import List
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
@@ -12,10 +11,9 @@ from db.models.knowledgebase.user_role import (
 )
 from db.db_context import get_db_session
 from common.chat.response_model import ResponseModel, success_response
-from api.api_exception import ApiException
+from api.api_exception import ApiException, handle_api_exceptions
 from service.tool.role_service import RoleService
 from service.injection import get_role_service
-from loguru import logger
 from service.injection import get_tenant_id
 
 role_router = APIRouter()
@@ -23,25 +21,20 @@ role_router = APIRouter()
 # 角色API
 
 @role_router.post("", response_model=ResponseModel[RoleEntity])
+@handle_api_exceptions(action="create role", default_code=400)
 async def create_role(
     role: RoleEntity,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     role_service: RoleService = Depends(get_role_service),
 ):
-    try:
-        role = await role_service.create_role(role=role, tenant_id=tenant_id)
-        return success_response(data=role, message="Create role success.")
-    except ValueError as e:
-        logger.error(f"Failed to create role: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create role: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Create role failed: '{e}'.")
+    role = await role_service.create_role(role=role, tenant_id=tenant_id)
+    return success_response(data=role, message="Create role success.")
 
 
 
 @role_router.get("")
+@handle_api_exceptions(action="list roles", default_code=400)
 async def list_roles(
     name: str = None,
     page: int = Query(default=1, ge=1),
@@ -50,64 +43,47 @@ async def list_roles(
     session: AsyncSession = Depends(get_db_session),
     role_service: RoleService = Depends(get_role_service),
 ):
-    try:
-        if name:
-            # If name is provided, get single role by name
-            role = await role_service.get_role_by_name(name)
-            if not role:
-                raise ApiException(
-                    code=404, message=f"Get role failed: '{name}' does not exist."
-                )
-            return success_response(data=role, message="Get role successful.")
-        else:
-            # List all roles with pagination
-            roles = await role_service.list_roles(page=page, size=size, tenant_id=tenant_id)
-            return success_response(data=roles, message="List role successful")
-    except Exception as e:
-        logger.error(f"Failed to list roles: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"List roles failed: '{e}'.")
+    if name:
+        # If name is provided, get single role by name
+        role = await role_service.get_role_by_name(name)
+        if not role:
+            raise ApiException(
+                code=404, message=f"Get role failed: '{name}' does not exist."
+            )
+        return success_response(data=role, message="Get role successful.")
+    # List all roles with pagination
+    roles = await role_service.list_roles(page=page, size=size, tenant_id=tenant_id)
+    return success_response(data=roles, message="List role successful")
 
 
 @role_router.delete("/{role_id}")
+@handle_api_exceptions(action="delete role", default_code=400)
 async def delete_role(
     role_id: str,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     role_service: RoleService = Depends(get_role_service),
 ):
-    try:
-        await role_service.delete_role(role_id=role_id, tenant_id=tenant_id)
-        logger.info(f"Role {role_id} deleted successfully.")
-        return success_response(message=f"Role {role_id} deletion successful.")
-    except ValueError as e:
-        logger.error(f"Failed to delete role: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete role: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Delete role failed: '{e}'.")
+    await role_service.delete_role(role_id=role_id, tenant_id=tenant_id)
+    return success_response(message=f"Role {role_id} deletion successful.")
 
 
 # 用户-角色 API
 @role_router.post("/user_roles", response_model=ResponseModel[UserRoleEntity])
+@handle_api_exceptions(action="create user role", default_code=400)
 async def create_user_role(
     user_role: UserRoleEntity,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     role_service: RoleService = Depends(get_role_service),
 ):
-    try:
-        user_role = await role_service.create_user_role(user_role=user_role, tenant_id=tenant_id)
-        return success_response(data=user_role, message="Create user role successful.")
-    except ValueError as e:
-        logger.error(f"Failed to create user role: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create user role: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Create user role failed: '{e}'.")
+    user_role = await role_service.create_user_role(user_role=user_role, tenant_id=tenant_id)
+    return success_response(data=user_role, message="Create user role successful.")
 
 
 
 @role_router.get("/user_roles")
+@handle_api_exceptions(action="list user roles", default_code=400)
 async def list_user_roles(
     user_id: str = None,
     page: int = Query(default=1, ge=1),
@@ -116,59 +92,40 @@ async def list_user_roles(
     session: AsyncSession = Depends(get_db_session),
     role_service: RoleService = Depends(get_role_service),
 ):
-    try:
-        user_roles = await role_service.list_user_roles(page=page, size=size, user_id=user_id, tenant_id=tenant_id)
-        return success_response(data=user_roles, message="List user roles successful")
-    except Exception as e:
-        logger.error(f"Failed to list user roles: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"List user roles failed: '{e}'.")
+    user_roles = await role_service.list_user_roles(page=page, size=size, user_id=user_id, tenant_id=tenant_id)
+    return success_response(data=user_roles, message="List user roles successful")
 
 
 @role_router.delete("/user_roles/{user_role_id}")
+@handle_api_exceptions(action="delete user role", default_code=400)
 async def delete_user_role(
     user_role_id: str,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     role_service: RoleService = Depends(get_role_service),
 ):
-    try:
-        await role_service.delete_user_role(user_role_id=user_role_id, tenant_id=tenant_id)
-        logger.info(f"User role {user_role_id} deleted successfully.")
-        return success_response(message=f"User role {user_role_id} deletion successful.")
-    except ValueError as e:
-        logger.error(f"Failed to delete user role: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete user role: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Delete user role failed: '{e}'.")
+    await role_service.delete_user_role(user_role_id=user_role_id, tenant_id=tenant_id)
+    return success_response(message=f"User role {user_role_id} deletion successful.")
 
 
 
 # Permission API
 @role_router.post("/permissions", response_model=ResponseModel[PermissionEntity])
+@handle_api_exceptions(action="create permission", default_code=400)
 async def create_permission(
     permission: PermissionEntity,
     session: AsyncSession = Depends(get_db_session),
     role_service: RoleService = Depends(get_role_service),
     tenant_id: str = Depends(get_tenant_id),
 ):
-    try:
-        permission = await role_service.create_permission(permission, tenant_id=tenant_id)
-        await session.commit()
-        await session.refresh(permission)
-        return success_response(data=permission, message="Create permission successful.")
-    except ValueError as e:
-        logger.error(f"Failed to create permission: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create permission: {traceback.format_exc()}")
-        await session.rollback()
-        raise ApiException(code=400, message=f"Create permission failed: '{e}'.")
+    permission = await role_service.create_permission(permission, tenant_id=tenant_id)
+    await session.refresh(permission)
+    return success_response(data=permission, message="Create permission successful.")
 
 
 
 @role_router.get("/permissions")
+@handle_api_exceptions(action="list permissions", default_code=400)
 async def list_permissions(
     name: str = None,
     page: int = Query(default=1, ge=1),
@@ -177,12 +134,8 @@ async def list_permissions(
     role_service: RoleService = Depends(get_role_service),
     tenant_id: str = Depends(get_tenant_id),
 ):
-    try:
-        permissions = await role_service.list_permissions(page=page, size=size, name=name, tenant_id=tenant_id)
-        return success_response(data=permissions, message="List permissions successful")
-    except Exception as e:
-        logger.error(f"Failed to list permissions: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"List permissions failed: '{e}'.")
+    permissions = await role_service.list_permissions(page=page, size=size, name=name, tenant_id=tenant_id)
+    return success_response(data=permissions, message="List permissions successful")
 
 
 
@@ -192,6 +145,7 @@ class UpdateRolePermission(BaseModel):
 
 
 @role_router.post("/permissions/files/{file_id}")
+@handle_api_exceptions(action="set file permissions", default_code=400)
 async def set_file_permission(
     file_id: str,
     update_request: UpdateRolePermission,
@@ -199,34 +153,20 @@ async def set_file_permission(
     role_service: RoleService = Depends(get_role_service),
     tenant_id: str = Depends(get_tenant_id),
 ):
-    try:
-        new_permissions = await role_service.set_file_permissions(
-            file_id, update_request.role_ids, tenant_id=tenant_id
-        )
-        return success_response(data=new_permissions, message="Update permissions successful")
-    except ValueError as e:
-        logger.error(f"Set file permissions failed: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as ex:
-        logger.error(f"Set file permissions failed: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Set file permissions failed: {ex}")
+    new_permissions = await role_service.set_file_permissions(
+        file_id, update_request.role_ids, tenant_id=tenant_id
+    )
+    return success_response(data=new_permissions, message="Update permissions successful")
 
 
 
 @role_router.delete("/permissions/{permission_id}")
+@handle_api_exceptions(action="delete permission", default_code=400)
 async def delete_permission(
     permission_id: str,
     session: AsyncSession = Depends(get_db_session),
     role_service: RoleService = Depends(get_role_service),
     tenant_id: str = Depends(get_tenant_id),
 ):
-    try:
-        await role_service.delete_permission(permission_id, tenant_id=tenant_id)
-        logger.info(f"Permission {permission_id} deleted successfully.")
-        return success_response(message=f"Permission {permission_id} deletion successful.")
-    except ValueError as e:
-        logger.error(f"Failed to delete permission: {str(e)}")
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete permission: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Delete permission failed: '{e}'.")
+    await role_service.delete_permission(permission_id, tenant_id=tenant_id)
+    return success_response(message=f"Permission {permission_id} deletion successful.")

--- a/backend/api/v1/embed.py
+++ b/backend/api/v1/embed.py
@@ -1,6 +1,5 @@
-import traceback
 from typing import List
-from api.api_exception import ApiException
+from api.api_exception import ApiException, handle_api_exceptions
 from common.knowledgebase.constants import DEFAULT_EMBEDDING_MODEL
 from fastapi import APIRouter
 from pydantic import BaseModel
@@ -27,6 +26,7 @@ class EmbeddingInput(BaseModel):
 
 
 @embedding_router.post("")
+@handle_api_exceptions(action="embed")
 async def aembed(
     embedding_input: EmbeddingInput,
     tenant_id: str = Depends(get_tenant_id),
@@ -54,34 +54,27 @@ async def aembed(
     if embedding_input.model == "bge-m3":
         embedding_input.model = DEFAULT_EMBEDDING_MODEL
 
-    try:
-        embedding_entity = await embedding_service.get_embedding_by_model_id(embedding_input.model, tenant_id=tenant_id)
-        if not embedding_entity:
-            raise ApiException(code=400, message=f"Embedding model {embedding_input.model} not found.")
+    embedding_entity = await embedding_service.get_embedding_by_model_id(embedding_input.model, tenant_id=tenant_id)
+    if not embedding_entity:
+        raise ApiException(code=400, message=f"Embedding model {embedding_input.model} not found.")
 
-        embed_model = create_embedding_model(embedding_entity)
-        text_embeddings = await embed_model.aget_text_embedding_batch(text_inputs)
-        embedding_data_list = [
-            Embedding(
-                embedding=embedding,
-                index=i,
-                object="embedding",
-            )
-            for i, embedding in enumerate(text_embeddings)
-        ]
-        logger.info(f"aembed: finished embedding {len(embedding_data_list)} texts.")
-        return CreateEmbeddingResponse(
-            object="list",
-            data=embedding_data_list,
-            model=embedding_input.model,
-            usage=EmbeddingUsage(
-                prompt_tokens=0,
-                total_tokens=0,
-            ),
+    embed_model = create_embedding_model(embedding_entity)
+    text_embeddings = await embed_model.aget_text_embedding_batch(text_inputs)
+    embedding_data_list = [
+        Embedding(
+            embedding=embedding,
+            index=i,
+            object="embedding",
         )
-    except ValueError as ve:
-        logger.warning(f"Embedding failed due to value error: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Embedding failed: {ve}")
-    except Exception as ex:
-        logger.error(f"Embedding failed: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Embedding failed: {ex}")
+        for i, embedding in enumerate(text_embeddings)
+    ]
+    logger.info(f"aembed: finished embedding {len(embedding_data_list)} texts.")
+    return CreateEmbeddingResponse(
+        object="list",
+        data=embedding_data_list,
+        model=embedding_input.model,
+        usage=EmbeddingUsage(
+            prompt_tokens=0,
+            total_tokens=0,
+        ),
+    )

--- a/backend/api/v1/faq_retrieval.py
+++ b/backend/api/v1/faq_retrieval.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from typing import Optional, List
 from common.chat.response_model import ResponseModel, success_response
-from api.api_exception import ApiException
+from api.api_exception import ApiException, handle_api_exceptions
 from db.db_context import get_db_session
 from common.chat.models import DocRecord, NewRetrievalResponse, RetrievalSetting, MetadataFilteringCondition
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -14,7 +14,6 @@ from service.knowledgebase.knowledgebase_service import KnowledgebaseService
 from common.knowledgebase.constants import DEFAULT_FAQ_SIMILARITY_THRESHOLD
 from common.knowledgebase.types import VectorIndexRetrievalType
 from common.tool.search_result import SearchResult
-import traceback
 from loguru import logger
 
 
@@ -32,6 +31,7 @@ class FAQRetrievalRequest(BaseModel):
 @faq_retrieval_router.post(
     "", response_model=ResponseModel[NewRetrievalResponse]
 )
+@handle_api_exceptions(action="retrieve FAQ")
 async def faq_retrieval(
     retrieval_request: FAQRetrievalRequest,
     session: AsyncSession = Depends(get_db_session),
@@ -41,84 +41,75 @@ async def faq_retrieval(
     faq_config_service: FAQConfigService = Depends(get_faq_config_service),
 ):
     logger.info(f"FAQ Retrieval request: chatapp_id={retrieval_request.chatapp_id}, query={retrieval_request.query}, tenant_id={tenant_id}")
-    try:
-        chatbot = await chatapp_service.get_chatapp_by_app_id(
-            app_id=retrieval_request.chatapp_id,
-            tenant_id=tenant_id
+    chatbot = await chatapp_service.get_chatapp_by_app_id(
+        app_id=retrieval_request.chatapp_id,
+        tenant_id=tenant_id
+    )
+    if not chatbot:
+        raise ApiException(code=404, message=f"Application '{retrieval_request.chatapp_id}' does not exist.")
+
+    # Get FAQ config to get similarity_threshold
+    faq_config = chatbot.faq_config
+    if not faq_config:
+        raise ApiException(code=404, message=f"FAQ configuration '{retrieval_request.chatapp_id}' does not exist.")
+
+
+    kb_id = faq_config.kb_id
+    knowledgebase_service = KnowledgebaseService(session)
+    kb = await knowledgebase_service.get_knowledgebase(kb_id, tenant_id=tenant_id)
+
+    if not kb:
+        raise ApiException(code=404, message=f"FAQ knowledge base '{kb_id}' does not exist.")
+
+    # Set default retrieval_setting if not provided, or merge with defaults
+    default_similarity_threshold = faq_config.similarity_threshold if faq_config else DEFAULT_FAQ_SIMILARITY_THRESHOLD
+
+    if retrieval_request.retrieval_setting is None:
+        retrieval_setting = RetrievalSetting(
+            retrieval_mode=VectorIndexRetrievalType.vector,
+            top_k=1,
+            enable_rerank=False,
+            rerank_top_k=None,
+            vector_weight=1.0,
+            similarity_threshold=default_similarity_threshold,
         )
-        if not chatbot:
-            raise ApiException(code=404, message=f"Application '{retrieval_request.chatapp_id}' does not exist.")
-
-        # Get FAQ config to get similarity_threshold
-        faq_config = chatbot.faq_config
-        if not faq_config:
-            raise ApiException(code=404, message=f"FAQ configuration '{retrieval_request.chatapp_id}' does not exist.")
-
-
-        kb_id = faq_config.kb_id
-        knowledgebase_service = KnowledgebaseService(session)
-        kb = await knowledgebase_service.get_knowledgebase(kb_id, tenant_id=tenant_id)
-
-        if not kb:
-            raise ApiException(code=404, message=f"FAQ knowledge base '{kb_id}' does not exist.")
-
-        # Set default retrieval_setting if not provided, or merge with defaults
-        default_similarity_threshold = faq_config.similarity_threshold if faq_config else DEFAULT_FAQ_SIMILARITY_THRESHOLD
-
-        if retrieval_request.retrieval_setting is None:
-            retrieval_setting = RetrievalSetting(
-                retrieval_mode=VectorIndexRetrievalType.vector,
-                top_k=1,
-                enable_rerank=False,
-                rerank_top_k=None,
-                vector_weight=1.0,
-                similarity_threshold=default_similarity_threshold,
-            )
-        else:
-            # Merge user-provided settings with defaults
-            retrieval_setting = RetrievalSetting(
-                retrieval_mode=retrieval_request.retrieval_setting.retrieval_mode or VectorIndexRetrievalType.vector,
-                top_k=retrieval_request.retrieval_setting.top_k if retrieval_request.retrieval_setting.top_k is not None else 1,
-                enable_rerank=retrieval_request.retrieval_setting.enable_rerank if retrieval_request.retrieval_setting.enable_rerank is not None else False,
-                rerank_top_k=retrieval_request.retrieval_setting.rerank_top_k,
-                rerank_model=retrieval_request.retrieval_setting.rerank_model,
-                rerank_provider_name=retrieval_request.retrieval_setting.rerank_provider_name,
-                vector_weight=retrieval_request.retrieval_setting.vector_weight if retrieval_request.retrieval_setting.vector_weight is not None else 1.0,
-                similarity_threshold=retrieval_request.retrieval_setting.similarity_threshold if retrieval_request.retrieval_setting.similarity_threshold is not None else default_similarity_threshold,
-                score_threshold=retrieval_request.retrieval_setting.score_threshold,
-            )
-
-        search_results: List[SearchResult] = await rag_service.aquery(
-            query=retrieval_request.query,
-            user_id=retrieval_request.user_id,
-            kb_id=kb.id,
-            kb_id_list=None,
-            retrieval_setting=retrieval_setting,
-            metadata_condition=None,
-            tenant_id=tenant_id,
+    else:
+        # Merge user-provided settings with defaults
+        retrieval_setting = RetrievalSetting(
+            retrieval_mode=retrieval_request.retrieval_setting.retrieval_mode or VectorIndexRetrievalType.vector,
+            top_k=retrieval_request.retrieval_setting.top_k if retrieval_request.retrieval_setting.top_k is not None else 1,
+            enable_rerank=retrieval_request.retrieval_setting.enable_rerank if retrieval_request.retrieval_setting.enable_rerank is not None else False,
+            rerank_top_k=retrieval_request.retrieval_setting.rerank_top_k,
+            rerank_model=retrieval_request.retrieval_setting.rerank_model,
+            rerank_provider_name=retrieval_request.retrieval_setting.rerank_provider_name,
+            vector_weight=retrieval_request.retrieval_setting.vector_weight if retrieval_request.retrieval_setting.vector_weight is not None else 1.0,
+            similarity_threshold=retrieval_request.retrieval_setting.similarity_threshold if retrieval_request.retrieval_setting.similarity_threshold is not None else default_similarity_threshold,
+            score_threshold=retrieval_request.retrieval_setting.score_threshold,
         )
 
-        logger.info(
-            f"Retrieved {len(search_results)} FAQ results for query '{retrieval_request.query}' from knowledgebase {kb.id}."
-        )
+    search_results: List[SearchResult] = await rag_service.aquery(
+        query=retrieval_request.query,
+        user_id=retrieval_request.user_id,
+        kb_id=kb.id,
+        kb_id_list=None,
+        retrieval_setting=retrieval_setting,
+        metadata_condition=None,
+        tenant_id=tenant_id,
+    )
 
-        records = []
-        for node in search_results:
-            records.append(DocRecord(
-                content=node.content,
-                score=node.score,
-                title=node.title,
-                metadata=node.metadata,
-            ))
+    logger.info(
+        f"Retrieved {len(search_results)} FAQ results for query '{retrieval_request.query}' from knowledgebase {kb.id}."
+    )
 
-        # Use unified response format
-        retrieval_response = NewRetrievalResponse(records=records)
-        return success_response(data=retrieval_response, message="FAQ retrieval succeeded.")
-    except ApiException:
-        raise
-    except ValueError as e:
-        logger.error(f"Failed to retrieve FAQ: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"FAQ retrieval failed: {e}")
-    except Exception as e:
-        logger.error(f"Failed to retrieve FAQ: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"FAQ retrieval failed: {e}")
+    records = []
+    for node in search_results:
+        records.append(DocRecord(
+            content=node.content,
+            score=node.score,
+            title=node.title,
+            metadata=node.metadata,
+        ))
+
+    # Use unified response format
+    retrieval_response = NewRetrievalResponse(records=records)
+    return success_response(data=retrieval_response, message="FAQ retrieval succeeded.")

--- a/backend/api/v1/retrieval.py
+++ b/backend/api/v1/retrieval.py
@@ -1,13 +1,12 @@
 from fastapi import APIRouter, Depends
 from common.chat.response_model import ResponseModel
-from api.api_exception import ApiException
+from api.api_exception import handle_api_exceptions
 from common.chat.models import DocRecord, NewRetrievalResponse, RetrievalRequest
 from service.injection import get_rag_service, get_tenant_id
 from service.knowledgebase.rag_service import RagService
 from typing import List
 from common.tool.search_result import SearchResult
 from fastapi.responses import JSONResponse
-import traceback
 from extensions.trace.context import get_request_id
 from loguru import logger
 
@@ -17,6 +16,7 @@ retrieval_router = APIRouter()
 @retrieval_router.post(
     "", response_model=ResponseModel[NewRetrievalResponse]
 )
+@handle_api_exceptions(action="retrieve")
 async def retrieval(
     retrieval_request: RetrievalRequest,
     tenant_id: str = Depends(get_tenant_id),
@@ -24,37 +24,30 @@ async def retrieval(
 ):
     request_id = get_request_id()
     logger.info(f"Retrieval request: {retrieval_request}, tenant_id: {tenant_id}, request_id: {request_id}")
-    try:
-        search_results: List[SearchResult] = await rag_service.aquery(
-            query=retrieval_request.query,
-            user_id=retrieval_request.user_id,
-            kb_id=retrieval_request.knowledge_id,
-            kb_id_list=retrieval_request.knowledge_id_list,
-            retrieval_setting=retrieval_request.retrieval_setting,
-            metadata_condition=retrieval_request.metadata_condition,
-            tenant_id=tenant_id,
-        )
-        logger.info(
-            f"Retrieved {len(search_results)} for query '{retrieval_request.query}', request_id: {request_id}"
-        )
-        records = []
-        for node in search_results:
-            records.append(DocRecord(
-                content=node.content,
-                score=node.score,
-                title=node.title,
-                url=node.url,
-                metadata=node.metadata,
-            ))
-        # 使用统一的响应格式
-        retrieval_response = NewRetrievalResponse(records=records)
-        retrieval_response_data = retrieval_response.model_dump()
-        logger.info(f"Retrieval response: {retrieval_response_data}, request_id: {request_id}")
+    search_results: List[SearchResult] = await rag_service.aquery(
+        query=retrieval_request.query,
+        user_id=retrieval_request.user_id,
+        kb_id=retrieval_request.knowledge_id,
+        kb_id_list=retrieval_request.knowledge_id_list,
+        retrieval_setting=retrieval_request.retrieval_setting,
+        metadata_condition=retrieval_request.metadata_condition,
+        tenant_id=tenant_id,
+    )
+    logger.info(
+        f"Retrieved {len(search_results)} for query '{retrieval_request.query}', request_id: {request_id}"
+    )
+    records = []
+    for node in search_results:
+        records.append(DocRecord(
+            content=node.content,
+            score=node.score,
+            title=node.title,
+            url=node.url,
+            metadata=node.metadata,
+        ))
+    # 使用统一的响应格式
+    retrieval_response = NewRetrievalResponse(records=records)
+    retrieval_response_data = retrieval_response.model_dump()
+    logger.info(f"Retrieval response: {retrieval_response_data}, request_id: {request_id}")
 
-        return JSONResponse(status_code=200, content=retrieval_response_data)
-    except ValueError as e:
-        logger.error(f"Failed to retrieve: {traceback.format_exc()}")
-        raise ApiException(code=400, message=f"Failed to retrieve: {e}")
-    except Exception as e:
-        logger.error(f"Failed to retrieve: {traceback.format_exc()}")
-        raise ApiException(code=500, message=f"Failed to retrieve: {e}")
+    return JSONResponse(status_code=200, content=retrieval_response_data)

--- a/backend/api/v1/thread.py
+++ b/backend/api/v1/thread.py
@@ -8,7 +8,7 @@ from db.models.thread import ThreadCreate, ThreadRead
 from db.models.message import MessageCreate, MessageRead
 from typing import List
 from common.chat.response_model import success_response, ResponseModel
-from api.api_exception import ApiException
+from api.api_exception import ApiException, handle_api_exceptions
 from common.chat.prompts import DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE
 from utils.message_utils import get_content_from_messages
 from llama_index.core.base.llms.types import MessageRole
@@ -27,32 +27,23 @@ thread_router = APIRouter()
 
 
 @thread_router.post("", response_model=ResponseModel[ThreadRead])
+@handle_api_exceptions(action="create conversation", default_code=400)
 async def create_thread(
     thread: ThreadCreate,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     thread_service: ThreadService = Depends(get_thread_service),
 ):
-    try:
-        thread_entity = await thread_service.create_thread(thread, tenant_id=tenant_id)
-        await session.commit()
-        await session.refresh(thread_entity)
-        return success_response(
-            data=thread_entity, message="Conversation created successfully."
-        )
-    except ValueError as e:
-        logger.error(f"Failed to create thread: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create thread: {str(e)}")
-        await session.rollback()
-        raise ApiException(
-            code=400, message=f"Failed to add conversation: {str(e)}"
-        )
+    thread_entity = await thread_service.create_thread(thread, tenant_id=tenant_id)
+    await session.commit()
+    await session.refresh(thread_entity)
+    return success_response(
+        data=thread_entity, message="Conversation created successfully."
+    )
 
 
 @thread_router.get("", response_model=ResponseModel[List[ThreadRead]])
+@handle_api_exceptions(action="list conversations", default_code=400)
 async def get_threads(
     session: AsyncSession = Depends(get_db_session),
     offset: int = 0,
@@ -60,25 +51,20 @@ async def get_threads(
     tenant_id: str = Depends(get_tenant_id),
     thread_service: ThreadService = Depends(get_thread_service),
 ):
-    try:
-        thread_entities = await thread_service.list_threads(
-            tenant_id=tenant_id,
-            offset=offset,
-            limit=limit,
-        )
-        thread_models = [
-            ThreadRead.model_validate(thread) for thread in thread_entities
-        ]
-        return success_response(
-            data=thread_models, message="Get conversations successfully."
-        )
-    except Exception as e:
-        logger.error(f"Failed to get threads: {str(e)}")
-        raise ApiException(
-            code=400, message=f"Failed to get conversations: {str(e)}"
-        )
+    thread_entities = await thread_service.list_threads(
+        tenant_id=tenant_id,
+        offset=offset,
+        limit=limit,
+    )
+    thread_models = [
+        ThreadRead.model_validate(thread) for thread in thread_entities
+    ]
+    return success_response(
+        data=thread_models, message="Get conversations successfully."
+    )
 
 @thread_router.delete("/{thread_id}")
+@handle_api_exceptions(action="delete conversation", value_error_code=404, default_code=400)
 async def delete_thread(
     thread_id: str,
     tenant_id: str = Depends(get_tenant_id),
@@ -86,31 +72,21 @@ async def delete_thread(
     thread_service: ThreadService = Depends(get_thread_service),
     message_service: MessageService = Depends(get_message_service),
 ):
-    try:
-        # Release file refs FIRST. Any error here must abort the whole request
-        # — otherwise the thread is gone but ref_counts stay elevated with no
-        # way to reach them, and the files would be pinned forever.
-        await message_service.release_attachment_refs(thread_id, tenant_id=tenant_id)
+    # Release file refs FIRST. Any error here must abort the whole request
+    # — otherwise the thread is gone but ref_counts stay elevated with no
+    # way to reach them, and the files would be pinned forever.
+    await message_service.release_attachment_refs(thread_id, tenant_id=tenant_id)
 
-        # Delete the thread
-        await thread_service.delete_thread(thread_id, tenant_id=tenant_id)
-        await session.commit()
+    # Delete the thread
+    await thread_service.delete_thread(thread_id, tenant_id=tenant_id)
+    await session.commit()
 
-        return success_response(
-            code=200, message=f"Conversation {thread_id} deleted."
-        )
-    except ValueError as e:
-        logger.error(f"Failed to delete thread: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=404, message=str(e))
-    except Exception as e:
-        logger.error(f"Failed to delete thread: {str(e)}")
-        await session.rollback()
-        raise ApiException(
-            code=400, message=f"Failed to delete conversation: {str(e)}"
-        )
+    return success_response(
+        code=200, message=f"Conversation {thread_id} deleted."
+    )
 
 @thread_router.post("/{thread_id}/title")
+@handle_api_exceptions(action="update conversation title", default_code=400)
 async def update_thread_title(
     thread_id: str,
     messages: List[MessageCreate],
@@ -122,85 +98,72 @@ async def update_thread_title(
     logger.info(
         f"Updating conversation {thread_id} title based on messages {messages}."
     )
+    thread = await thread_service.get_thread(thread_id, tenant_id=tenant_id)
+    if not thread:
+        raise ApiException(
+            code=404, message=f"Conversation {thread_id} not found."
+        )
+
+    title = "未命名会话"
     try:
-        thread = await thread_service.get_thread(thread_id, tenant_id=tenant_id)
-        if not thread:
-            raise ApiException(
-                code=404, message=f"Conversation {thread_id} not found."
-            )
+        # Get first LLM model from database
+        llm_entities = await llm_service.get_all_llms(tenant_id=tenant_id)
+        if not llm_entities:
+            raise ValueError("No LLM models found in database.")
 
-        title = "未命名会话"
-        try:
-            # Get first LLM model from database
-            llm_entities = await llm_service.get_all_llms(tenant_id=tenant_id)
-            if not llm_entities:
-                raise ValueError("No LLM models found in database.")
+        llm_model = llm_entities[0]
+        llm = create_llm(llm_model)
 
-            llm_model = llm_entities[0]
-            llm = create_llm(llm_model)
-
-            # Generate title using LLM
-            generate_title_prompt = DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE.format(
-                chat_history="\n".join(
-                    [
-                        f"{msg.role}: {get_content_from_messages(msg.content)}"
-                        for msg in messages
-                    ]
-                )
-            )
-            chat_response_gen = await llm.astream(
-                messages=[
-                    {
-                        "role": MessageRole.USER,
-                        "content": generate_title_prompt,
-                    }
+        # Generate title using LLM
+        generate_title_prompt = DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE.format(
+            chat_history="\n".join(
+                [
+                    f"{msg.role}: {get_content_from_messages(msg.content)}"
+                    for msg in messages
                 ]
             )
-            response_text = ""
-            async for chunk in chat_response_gen:
-                response_text += chunk.delta
-
-            extracted_content = re.sub(
-                r"<think>.*?</think>",
-                "",
-                response_text,
-                flags=re.DOTALL,
-            )
-            logger.info(f"Generated title: {extracted_content}")
-            title = json.loads(extracted_content).get("title", "未命名会话")
-        except Exception as e:
-            logger.error(f"Failed to update conversation {thread_id} title: {e}")
-            # Fallback to simple title
-            title = (
-                f"{get_content_from_messages(messages[0].content)[:10]}..."
-                if messages
-                else "未命名会话"
-            )
-
-        # Update thread title
-        await thread_service.update_thread_title(thread_id, title, tenant_id=tenant_id)
-        await session.commit()
-
-        logger.info(f"Conversation {thread_id} updated title to {title}.")
-        return success_response(
-            data={"title": title},
-            message=f"Conversation {thread_id} title updated successfully.",
         )
-    except ApiException:
-        raise
-    except ValueError as e:
-        logger.error(f"Failed to update thread title: {str(e)}")
-        await session.rollback()
-        raise ApiException(code=400, message=str(e))
+        chat_response_gen = await llm.astream(
+            messages=[
+                {
+                    "role": MessageRole.USER,
+                    "content": generate_title_prompt,
+                }
+            ]
+        )
+        response_text = ""
+        async for chunk in chat_response_gen:
+            response_text += chunk.delta
+
+        extracted_content = re.sub(
+            r"<think>.*?</think>",
+            "",
+            response_text,
+            flags=re.DOTALL,
+        )
+        logger.info(f"Generated title: {extracted_content}")
+        title = json.loads(extracted_content).get("title", "未命名会话")
     except Exception as e:
-        logger.error(f"Failed to update thread title: {str(e)}")
-        await session.rollback()
-        raise ApiException(
-            code=400,
-            message=f"Failed to update conversation title: {str(e)}",
+        logger.error(f"Failed to update conversation {thread_id} title: {e}")
+        # Fallback to simple title
+        title = (
+            f"{get_content_from_messages(messages[0].content)[:10]}..."
+            if messages
+            else "未命名会话"
         )
+
+    # Update thread title
+    await thread_service.update_thread_title(thread_id, title, tenant_id=tenant_id)
+    await session.commit()
+
+    logger.info(f"Conversation {thread_id} updated title to {title}.")
+    return success_response(
+        data={"title": title},
+        message=f"Conversation {thread_id} title updated successfully.",
+    )
 
 @thread_router.post("/{thread_id}/messages", response_model=ResponseModel[MessageRead])
+@handle_api_exceptions(action="create message", default_code=400)
 async def create_thread_message(
     message: MessageCreate,
     tenant_id: str = Depends(get_tenant_id),
@@ -209,52 +172,38 @@ async def create_thread_message(
     message_service: MessageService = Depends(get_message_service),
 ):
     thread_id = message.thread_id
-    try:
-        # Verify thread exists
-        thread = await thread_service.get_thread(thread_id, tenant_id=tenant_id)
-        if not thread:
-            raise ApiException(
-                code=404, message=f"Conversation {thread_id} not found."
-            )
-
-        # Create or update message
-        message_entity = await message_service.create_message(message, tenant_id=tenant_id)
-        await session.refresh(message_entity)
-
-        return success_response(
-            data=message_entity, message="Message created successfully."
-        )
-    except ApiException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to create message: {str(e)}")
-        await session.rollback()
+    # Verify thread exists
+    thread = await thread_service.get_thread(thread_id, tenant_id=tenant_id)
+    if not thread:
         raise ApiException(
-            code=400, message=f"Failed to create message: {str(e)}"
+            code=404, message=f"Conversation {thread_id} not found."
         )
+
+    # Create or update message
+    message_entity = await message_service.create_message(message, tenant_id=tenant_id)
+    await session.refresh(message_entity)
+
+    return success_response(
+        data=message_entity, message="Message created successfully."
+    )
 
 
 @thread_router.get("/{thread_id}/messages", response_model=ResponseModel[List[MessageRead]])
+@handle_api_exceptions(action="retrieve messages", default_code=400)
 async def get_thread_messages(
     thread_id: str,
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_db_session),
     message_service: MessageService = Depends(get_message_service),
 ):
-    try:
-        message_entities = await message_service.list_messages(
-            thread_id=thread_id,
-            tenant_id=tenant_id,
-            limit=30,
-        )
-        message_models = [
-            MessageRead.model_validate(message) for message in message_entities
-        ]
-        return success_response(
-            data=message_models, message="Messages retrieved successfully."
-        )
-    except Exception as e:
-        logger.error(f"Failed to get messages: {str(e)}")
-        raise ApiException(
-            code=400, message=f"Failed to retrieve messages: {str(e)}"
-        )
+    message_entities = await message_service.list_messages(
+        thread_id=thread_id,
+        tenant_id=tenant_id,
+        limit=30,
+    )
+    message_models = [
+        MessageRead.model_validate(message) for message in message_entities
+    ]
+    return success_response(
+        data=message_models, message="Messages retrieved successfully."
+    )


### PR DESCRIPTION
## Summary
- Continues #867 by applying the `@handle_api_exceptions` decorator to the remaining v1 routers, removing ~450 lines of duplicated try/except/log/rollback scaffolding.
- Preserves original HTTP status codes (e.g. `default_code=400` where the originals returned 400; `value_error_code=404` on `delete_thread` so missing-thread IDs still return 404) and existing i18n error messages.
- Surgical migration on the two largest routers: simple CRUD routes are decorated, while complex orchestration paths are intentionally PRESERVED.

## Routers migrated this pass
- `backend/api/v1/config_apis/metadata.py`
- `backend/api/v1/config_apis/code_sandbox.py` (`default_code=400`, i18n)
- `backend/api/v1/config_apis/role/role.py` (`default_code=400`)
- `backend/api/v1/config_apis/evaluation.py` (23 routes; 3 keep `default_code=400`)
- `backend/api/v1/thread.py` (`default_code=400`; `delete_thread` uses `value_error_code=404`)
- `backend/api/v1/retrieval.py`
- `backend/api/v1/faq_retrieval.py`
- `backend/api/v1/embed.py`

## Surgical migrations (simple routes only)
- `backend/api/v1/config_apis/knowledgebase.py` — migrated 13 simple routes (kb/file CRUD with `default_code=400`; chunk CRUD with `default_code=500` matching their original code paths). Left untouched: `create_knowledgebase`, `update_knowledgebase`, `upload_files`, `start_parse_task`, `batch_operations` — they own bespoke cache rollback / Celery enqueue choreography that does not fit the decorator contract.
- `backend/api/v1/config_apis/chatapp.py` — migrated 8 simple routes (`default_code=500`, i18n). Left untouched: `upload_faq_files`, which owns nested `IntegrityError` handling plus a `try/finally` temp-file cleanup that is materially different from the standard error funnel.

## Test plan
- [x] `python -c "import ast; ..."` on all 10 modified files — all parse.
- [x] `python -m pytest tests/api/ -q --tb=no` → 27 failed, 95 passed, 11 skipped. **Identical to the pre-change baseline on this branch**; the remaining failures are pre-existing, unrelated issues outside the scope of this PR.
- [x] Pre-commit hooks (ruff, mypy, codespell, prettier, etc.) all pass.

🤖 Generated with [Claude Code](https://claude.ai/code)