### PR TITLE
fix(kb): inherit KB defaults for image caption model in reparse UI

### DIFF
--- a/frontend/app/knowledgebases/[kbId]/page.tsx
+++ b/frontend/app/knowledgebases/[kbId]/page.tsx
@@ -653,10 +653,11 @@ export default function KnowledgeBaseDetailPage(
     
     // 初始化切片配置：优先使用文件的chunk_config，否则使用知识库默认配置
     const initialConfig: any = file?.chunk_config || defaultConfig;
+    const kbChunkConfig: any = knowledgebase?.chunk_config || {};
     const config: any = {
       parser_type: initialConfig.parser_type || 'structure',
-      image_caption_model: initialConfig.image_caption_model,
-      image_caption_provider_name: initialConfig.image_caption_provider_name || 'openai_like',
+      image_caption_model: initialConfig.image_caption_model ?? kbChunkConfig.image_caption_model,
+      image_caption_provider_name: initialConfig.image_caption_provider_name ?? kbChunkConfig.image_caption_provider_name ?? 'openai_like',
     };
     
     if (initialConfig.parser_type === 'table') {
@@ -797,24 +798,21 @@ export default function KnowledgeBaseDetailPage(
     }
 
     setShowBatchReprocessDialog(false);
-    
-    // 获取第一个文件的chunk_config或使用知识库默认配置
+
     const fileIds = Array.from(selectedFiles);
-    const firstFile = kbfiles.find(f => fileIds.includes(f.id));
-    const defaultConfig = knowledgebase?.chunk_config || {
+
+    // 批量重新解析：直接使用知识库默认配置（多个文件可能有不同的文件级配置，统一以 KB 配置作为起点）
+    const initialConfig: any = knowledgebase?.chunk_config || {
       parser_type: 'structure',
       chunk_size: '1000',
       chunk_overlap: '50',
     };
-    
-    // 初始化切片配置：优先使用第一个文件的chunk_config，否则使用知识库默认配置
-    const initialConfig: any = firstFile?.chunk_config || defaultConfig;
     const config: any = {
       parser_type: initialConfig.parser_type || 'structure',
       image_caption_model: initialConfig.image_caption_model,
       image_caption_provider_name: initialConfig.image_caption_provider_name || 'openai_like',
     };
-    
+
     if (initialConfig.parser_type === 'table') {
       config.table_config = initialConfig.table_config || {
         concat_rows: false,


### PR DESCRIPTION
## Summary
- Single-file reprocess: image_caption_model / image_caption_provider_name now fall back to the knowledgebase chunk_config when the per-file value is null/undefined, so the dropdown no longer shows DISABLED when a KB default is configured.
- Batch reprocess: directly initialize from knowledgebase.chunk_config instead of picking the first selected file's config — selected files can have different per-file overrides and the KB config is the canonical default.

## Why
When uploading, the frontend always serializes \`image_caption_model: ... || null\` into the file-level chunk_config. On reprocess, the previous logic did \`file.chunk_config || defaultConfig\` at the object level — once the file had any chunk_config persisted, KB defaults were never consulted, so users saw "DISABLED" even though the KB has an image understanding model configured.

## Test plan
- [ ] In a KB with an image understanding model set as default, upload a file without selecting an image model. Trigger reprocess: dropdown should preselect the KB default model.
- [ ] Select multiple files (with mixed per-file configs) and trigger batch reprocess: dialog should preselect KB defaults across all fields (parser_type, chunk_size, image_caption_model, etc.).
- [ ] Trigger reprocess on a file that explicitly overrode the image model: it should still preselect the file's own override (per-file value wins when present).

🤖 Generated with [Claude Code](https://claude.ai/code)