### PR TITLE
[codex] Fix HTML reader table parsing

### DIFF
--- a/integrations/pairag-file/pairag/file/readers/html_reader.py
+++ b/integrations/pairag-file/pairag/file/readers/html_reader.py
@@ -103,6 +103,12 @@ class HtmlReader(BaseReader):
                         table_matrix[current_row_index + i][
                             current_col_index
                         ] = cell_content
+                    else:
+                        logger.warning(
+                            "Failed to apply rowspan cell at row "
+                            f"{current_row_index + i}, col {current_col_index}; "
+                            "table row is shorter than expected."
+                        )
                 max_rows = max(current_row_index + row_span, max_rows)
                 current_col_index += col_span
             if row_header_flag:
@@ -259,6 +265,7 @@ class HtmlReader(BaseReader):
         return content, saved_images
 
     def read(self, file_item: FileItem) -> List[Document]:
+        """Read an HTML file and return a single Markdown document."""
         file_item.file.seek(0)
         html_content = file_item.file.read().decode("utf-8")
         html_content = replace_consecutive_spaces(html_content)

--- a/integrations/pairag-file/pairag/file/readers/html_reader.py
+++ b/integrations/pairag-file/pairag/file/readers/html_reader.py
@@ -45,8 +45,12 @@ class HtmlReader(BaseReader):
             table.attrs['data-placeholder'] = placeholder
         return str(soup), tables
 
+    def _pad_rows_to_max_cols(self, table_matrix, max_cols):
+        for r in range(len(table_matrix)):
+            if len(table_matrix[r]) < max_cols:
+                table_matrix[r].extend([""] * (max_cols - len(table_matrix[r])))
+
     def _convert_table_to_pai_table(self, table):
-        # 标记header的index
         row_headers_index = []
         col_headers_index = []
         row_header_flag = True
@@ -64,6 +68,8 @@ class HtmlReader(BaseReader):
             if current_row_index >= max_rows:
                 table_matrix.append(row_cells)
                 max_rows += 1
+            else:
+                self._pad_rows_to_max_cols(table_matrix, max_cols)
             for cell in row.find_all(["th", "td"]):
                 if cell.name != "th":
                     row_header_flag = False
@@ -75,31 +81,28 @@ class HtmlReader(BaseReader):
                 if current_row_index != 0:
                     while (
                         current_col_index < max_cols
+                        and current_col_index < len(table_matrix[current_row_index])
                         and table_matrix[current_row_index][current_col_index] != ""
                     ):
                         current_col_index += 1
-                if (current_col_index > max_cols and max_cols != 0) or (
-                    current_row_index > max_rows and max_rows != 0
-                ):
-                    break
+                if current_col_index + col_span > max_cols:
+                    max_cols = current_col_index + col_span
+                    self._pad_rows_to_max_cols(table_matrix, max_cols)
                 for i in range(col_span):
-                    if current_row_index == 0:
-                        table_matrix[current_row_index].append(cell_content)
-                    elif current_col_index + i < max_cols:
+                    if current_col_index + i < len(table_matrix[current_row_index]):
                         table_matrix[current_row_index][
                             current_col_index + i
                         ] = cell_content
 
-                if current_row_index == 0:
-                    max_cols += col_span
                 for i in range(1, row_span):
                     if current_row_index + i >= max_rows:
                         row_cells = [""] * max_cols
                         table_matrix.append(row_cells)
                         max_rows += 1
-                    table_matrix[current_row_index + i][
-                        current_col_index
-                    ] = cell_content
+                    if current_col_index < len(table_matrix[current_row_index + i]):
+                        table_matrix[current_row_index + i][
+                            current_col_index
+                        ] = cell_content
                 max_rows = max(current_row_index + row_span, max_rows)
                 current_col_index += col_span
             if row_header_flag:
@@ -108,6 +111,9 @@ class HtmlReader(BaseReader):
 
         for i in range(col_header_index_max + 1):
             col_headers_index.append(i)
+
+        if not table_matrix:
+            table_matrix = [[]]
 
         table = PaiTable(
             data=table_matrix,
@@ -253,46 +259,41 @@ class HtmlReader(BaseReader):
         return content, saved_images
 
     def read(self, file_item: FileItem) -> List[Document]:
-        """
-        Read a CSV file and return a list of Documents.
-        """
-        try:
-            file_item.file.seek(0)
-            html_content = file_item.file.read().decode("utf-8")
-            html_content = replace_consecutive_spaces(html_content)
+        file_item.file.seek(0)
+        html_content = file_item.file.read().decode("utf-8")
+        html_content = replace_consecutive_spaces(html_content)
 
-            modified_html, tables = self._extract_tables(html_content)
+        modified_html, tables = self._extract_tables(html_content)
 
-            # 将 HTML 转换为 Markdown
-            markdown_content = markdownify(modified_html)
-            for table in tables:
-                # Use the stored placeholder (no underscore = no escape risk)
-                placeholder = table.attrs.get('data-placeholder')
-                if not placeholder:
-                    logger.warning("Table missing data-placeholder attribute")
-                    continue
-                    
+        markdown_content = markdownify(modified_html)
+        for table in tables:
+            placeholder = table.attrs.get('data-placeholder')
+            if not placeholder:
+                logger.warning("Table missing data-placeholder attribute")
+                continue
+
+            try:
                 table_markdown = self._convert_table_to_markdown(table) + "\n\n"
-                
-                if placeholder in markdown_content:
-                    markdown_content = markdown_content.replace(placeholder, table_markdown)
-                else:
-                    logger.warning(f"Placeholder '{placeholder}' not found in markdown")
-                    logger.debug(f"Content preview: {markdown_content[:300]}")
-            images = []
-            markdown_content, images = self._replace_image_paths(
-                markdown_content, file_item.kb_id + "/images/{}", tenant_id=file_item.tenant_id,
-            )
-            logger.info(
-                f"Successfully read {file_item.file_name} with images {images}."
-            )
+            except Exception as e:
+                logger.warning(f"Failed to convert table to markdown: {e}")
+                table_markdown = markdownify(str(table)) + "\n\n"
 
-            metadata = file_item.metadata()
+            if placeholder in markdown_content:
+                markdown_content = markdown_content.replace(placeholder, table_markdown)
+            else:
+                logger.warning(f"Placeholder '{placeholder}' not found in markdown")
+                logger.debug(f"Content preview: {markdown_content[:300]}")
+        images = []
+        markdown_content, images = self._replace_image_paths(
+            markdown_content, file_item.kb_id + "/images/{}", tenant_id=file_item.tenant_id,
+        )
+        logger.info(
+            f"Successfully read {file_item.file_name} with images {images}."
+        )
 
-            docs = [Document(id_=file_item.id, text=markdown_content, metadata=metadata)]
-            logger.info(f"Successfully read {file_item.file_name}.")
+        metadata = file_item.metadata()
 
-            return docs
-        except Exception as e:
-            logger.exception(e)
-            return []
+        docs = [Document(id_=file_item.id, text=markdown_content, metadata=metadata)]
+        logger.info(f"Successfully read {file_item.file_name}.")
+
+        return docs

--- a/integrations/pairag-file/tests/readers/test_html_reader.py
+++ b/integrations/pairag-file/tests/readers/test_html_reader.py
@@ -1,0 +1,22 @@
+from bs4 import BeautifulSoup
+
+from pairag.file.readers.html_reader import HtmlReader
+
+
+def test_table_with_rowspan_and_colspan_stays_rectangular():
+    table = BeautifulSoup(
+        """
+        <table>
+            <tr><th rowspan="2">Metric</th><th colspan="2">Values</th></tr>
+            <tr><th>Current</th><th>Target</th></tr>
+            <tr><td>Latency</td><td>10ms</td><td>8ms</td></tr>
+        </table>
+        """,
+        "html.parser",
+    ).find("table")
+
+    pai_table, total_cols = HtmlReader(file_store=None)._convert_table_to_pai_table(table)
+
+    assert total_cols == 3
+    assert all(len(row) == total_cols for row in pai_table.data)
+    assert pai_table.data[1] == ["Metric", "Current", "Target"]

--- a/integrations/pairag-file/tests/readers/test_html_reader.py
+++ b/integrations/pairag-file/tests/readers/test_html_reader.py
@@ -3,20 +3,77 @@ from bs4 import BeautifulSoup
 from pairag.file.readers.html_reader import HtmlReader
 
 
+def _convert_html_table(html: str):
+    table = BeautifulSoup(html, "html.parser").find("table")
+    return HtmlReader(file_store=None)._convert_table_to_pai_table(table)
+
+
 def test_table_with_rowspan_and_colspan_stays_rectangular():
-    table = BeautifulSoup(
+    pai_table, total_cols = _convert_html_table(
         """
         <table>
             <tr><th rowspan="2">Metric</th><th colspan="2">Values</th></tr>
             <tr><th>Current</th><th>Target</th></tr>
             <tr><td>Latency</td><td>10ms</td><td>8ms</td></tr>
         </table>
-        """,
-        "html.parser",
-    ).find("table")
-
-    pai_table, total_cols = HtmlReader(file_store=None)._convert_table_to_pai_table(table)
-
+        """
+    )
     assert total_cols == 3
     assert all(len(row) == total_cols for row in pai_table.data)
     assert pai_table.data[1] == ["Metric", "Current", "Target"]
+
+
+def test_empty_table_converts_to_empty_row():
+    pai_table, total_cols = _convert_html_table("<table></table>")
+
+    assert total_cols == 0
+    assert pai_table.data == [[]]
+
+
+def test_colspan_only_table_stays_rectangular():
+    pai_table, total_cols = _convert_html_table(
+        """
+        <table>
+            <tr><th colspan="2">Name</th><th>Score</th></tr>
+            <tr><td>Alice</td><td>A.</td><td>10</td></tr>
+        </table>
+        """
+    )
+
+    assert total_cols == 3
+    assert pai_table.data == [
+        ["Name", "Name", "Score"],
+        ["Alice", "A.", "10"],
+    ]
+
+
+def test_later_row_can_expand_table_width():
+    pai_table, total_cols = _convert_html_table(
+        """
+        <table>
+            <tr><th>Name</th></tr>
+            <tr><td>Alice</td><td>10</td><td>Active</td></tr>
+        </table>
+        """
+    )
+
+    assert total_cols == 3
+    assert pai_table.data == [
+        ["Name", "", ""],
+        ["Alice", "10", "Active"],
+    ]
+
+
+def test_malformed_table_is_normalized_by_parser():
+    pai_table, total_cols = _convert_html_table(
+        """
+        <table>
+            <tr><th>Name<th>Score
+            <tr><td>Alice<td>10
+        </table>
+        """
+    )
+
+    assert total_cols > 0
+    assert all(len(row) == total_cols for row in pai_table.data)
+    assert "Name" in pai_table.data[0][0]


### PR DESCRIPTION
## Summary
- Fix HTML table parsing when rowspan-created rows need to be widened by later colspan cells.
- Keep table conversion failures local to the affected table and fall back to markdownifying that table instead of dropping the whole HTML document.
- Add a focused regression test for rowspan + colspan table conversion.

## Tests
- `PYTHONPATH=. python -m pytest tests/readers/test_html_reader.py -q`

## Notes
- `test_readers.py::test_html_reader` could not be collected in the current local environment because the integration environment is missing `alibabacloud_oss_v2`; `poetry install --with dev` is currently blocked by a stale lock file (`pyproject.toml changed significantly since poetry.lock was last generated`).
