### PR TITLE
[codex] Expand Docker image workflow triggers

### DIFF
--- a/.github/workflows/docker-api.yml
+++ b/.github/workflows/docker-api.yml
@@ -13,11 +13,15 @@ on:
     branches: ["feature"]
     paths:
       - 'backend/**'
+      - 'integrations/**'
+      - 'resources/**'
       - 'alembic/**'
+      - 'alembic.ini'
       - 'scripts/**'
       - 'Dockerfile.api'
-      - 'pyproject.toml'
-      - 'poetry.lock'
+      - '**/pyproject.toml'
+      - '**/poetry.lock'
+      - '.github/workflows/docker-api.yml'
 
 # Environment variables for Container registry
 env:
@@ -69,4 +73,3 @@ jobs:
         run: |
           docker image prune --filter "until=168h" --force -a
           docker builder prune --filter "until=24h" -f
-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,11 +8,15 @@ on:
     paths:
       - 'backend/**'
       - 'frontend/**'
+      - 'integrations/**'
+      - 'resources/**'
       - 'alembic/**'
+      - 'alembic.ini'
       - 'scripts/**'
-      - 'pyproject.toml'
-      - 'poetry.lock'
+      - '**/pyproject.toml'
+      - '**/poetry.lock'
       - 'Dockerfile'
+      - '.github/workflows/docker.yml'
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:


### PR DESCRIPTION
## Summary
- Trigger the full Docker image workflow when `integrations/**`, `resources/**`, `alembic.ini`, any `pyproject.toml`, or any `poetry.lock` changes.
- Apply the same image-related trigger coverage to the API-only Docker image workflow.
- Include workflow file changes themselves in the relevant path filters.

## Validation
- Parsed `.github/workflows/docker.yml` and `.github/workflows/docker-api.yml` with PyYAML successfully.
