### PR TITLE
[codex] Keep tools for long LLM contexts

### DIFF
--- a/backend/common/llm/llm_model.py
+++ b/backend/common/llm/llm_model.py
@@ -107,23 +107,7 @@ class PaiLlm():
             is_reasoning = True
             has_reasoning_content = False
 
-            # If the context is very long, remove tools to avoid hallucination.
-            total_message_length = 0
-            for msg in messages:
-                msg_content = msg.get("content", "")
-                if msg_content:
-                    if isinstance(msg_content, list):
-                        for item in msg_content:
-                            if item.get("type") == "text":
-                                total_message_length += len(item.get("text" or ""))
-                    elif isinstance(msg_content, str):
-                        total_message_length += len(msg_content)
-
             tools_to_use = tools
-            if total_message_length >= 40000 and tools_to_use:
-                logger.warning(f"Removing {len(tools_to_use)} tool definitions to avoid hallucination.")
-                tools_to_use = None
-
             if not tools_to_use:
                 kwargs.pop("tool_choice", None) # pop choice if tools not given
 


### PR DESCRIPTION
## Summary

- Removes the long-context guard that dropped tool definitions before LLM calls.
- Keeps configured tools available even when message content is large.
- Still removes `tool_choice` when no tools are provided.

## Why

The previous length-based filter could make tool-aware requests lose their available tools solely because the conversation context was long. This change leaves tool availability to the runtime configuration instead of message length.

## Validation

- pre-commit hooks passed: ruff, mypy, prettier, codespell, whitespace, and related checks.
- pre-push AK leaking detection passed.
