### PR TITLE
fix(rerank): skip empty-text nodes before sending to rerank API

### DIFF
--- a/backend/rag/rerank/dashscope_reranker.py
+++ b/backend/rag/rerank/dashscope_reranker.py
@@ -209,17 +209,18 @@ class DashscopeReranker:
         if not vector_result:
             raise ValueError("VectorStoreQueryResult list cannot be empty")
 
-        if not vector_result.nodes or len(vector_result.nodes) <= 1:
-            return vector_result
-
-        # DashScope rejects empty documents; drop empty-text nodes before rerank
-        # while preserving each survivor's original similarity.
-        sims = vector_result.similarities or [0.0] * len(vector_result.nodes)
-        kept = [(n, s) for n, s in zip(vector_result.nodes, sims) if (n.text or "").strip()]
+        # DashScope rejects empty documents; drop empty-text nodes first while
+        # preserving each survivor's original similarity. Apply similarity_threshold
+        # to the sole survivor too — otherwise a low-score node bypasses the gate.
+        nodes = vector_result.nodes or []
+        sims = vector_result.similarities or [0.0] * len(nodes)
+        kept = [(n, s) for n, s in zip(nodes, sims) if (n.text or "").strip()]
         if not kept:
             return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
         if len(kept) == 1:
             only, sim = kept[0]
+            if sim < similarity_threshold:
+                return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
             return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[sim])
 
         origin_nodes = [n for n, _ in kept]

--- a/backend/rag/rerank/dashscope_reranker.py
+++ b/backend/rag/rerank/dashscope_reranker.py
@@ -212,14 +212,17 @@ class DashscopeReranker:
         if not vector_result.nodes or len(vector_result.nodes) <= 1:
             return vector_result
 
-        # DashScope rejects empty documents; drop empty-text nodes before rerank.
-        origin_nodes = [n for n in vector_result.nodes if (n.text or "").strip()]
-        if not origin_nodes:
+        # DashScope rejects empty documents; drop empty-text nodes before rerank
+        # while preserving each survivor's original similarity.
+        sims = vector_result.similarities or [0.0] * len(vector_result.nodes)
+        kept = [(n, s) for n, s in zip(vector_result.nodes, sims) if (n.text or "").strip()]
+        if not kept:
             return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
-        if len(origin_nodes) == 1:
-            only = origin_nodes[0]
-            return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[1.0])
+        if len(kept) == 1:
+            only, sim = kept[0]
+            return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[sim])
 
+        origin_nodes = [n for n, _ in kept]
         documents = [node.text for node in origin_nodes]
         rerank_results = await self.rerank(query, documents, model, top_n, similarity_threshold)
 

--- a/backend/rag/rerank/dashscope_reranker.py
+++ b/backend/rag/rerank/dashscope_reranker.py
@@ -212,7 +212,14 @@ class DashscopeReranker:
         if not vector_result.nodes or len(vector_result.nodes) <= 1:
             return vector_result
 
-        origin_nodes = vector_result.nodes
+        # DashScope rejects empty documents; drop empty-text nodes before rerank.
+        origin_nodes = [n for n in vector_result.nodes if (n.text or "").strip()]
+        if not origin_nodes:
+            return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
+        if len(origin_nodes) == 1:
+            only = origin_nodes[0]
+            return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[1.0])
+
         documents = [node.text for node in origin_nodes]
         rerank_results = await self.rerank(query, documents, model, top_n, similarity_threshold)
 

--- a/backend/rag/rerank/fusion_reranker.py
+++ b/backend/rag/rerank/fusion_reranker.py
@@ -96,6 +96,7 @@ def merge_vector_store_results_by_text(text_result: VectorStoreQueryResult, dens
     """
     合并两个 VectorStoreQueryResult，去重后返回合并结果。
     用于 reranker 场景，需要先合并再去重。
+    空文本节点会被跳过（rerank API 不接受空文档）。
 
     Args:
         text_result: 文本搜索结果
@@ -106,9 +107,13 @@ def merge_vector_store_results_by_text(text_result: VectorStoreQueryResult, dens
     """
     merged_nodes = {}
     for node, similarity in zip(text_result.nodes, text_result.similarities):
+        if not (node.text or "").strip():
+            continue
         merged_nodes[node.text] = (node, similarity, node.node_id)
 
     for node, similarity in zip(dense_result.nodes, dense_result.similarities):
+        if not (node.text or "").strip():
+            continue
         merged_nodes.setdefault(node.text, (node, similarity, node.node_id))
 
     if merged_nodes:

--- a/backend/rag/rerank/multimodal_dashscope_reranker.py
+++ b/backend/rag/rerank/multimodal_dashscope_reranker.py
@@ -25,6 +25,17 @@ DEFAULT_DASHSCOPE_MM_RERANK_ENDPOINT = (
 )
 
 
+def _node_has_renderable_content(node) -> bool:
+    """节点是否有可送入 rerank 的内容：非空文本 或 至少一张图片 URL。"""
+    if (node.text or "").strip():
+        return True
+    images_info = (node.metadata or {}).get("images_info") or []
+    for img in images_info:
+        if isinstance(img, dict) and img.get("url"):
+            return True
+    return False
+
+
 def _node_documents_with_images(nodes) -> List[Dict[str, Any]]:
     """将节点转换为多模态 rerank 可接受的 documents。
 
@@ -223,7 +234,14 @@ class MultimodalDashscopeReranker:
         if not vector_result.nodes or len(vector_result.nodes) <= 1:
             return vector_result
 
-        origin_nodes = vector_result.nodes
+        # Rerank API rejects empty documents; keep only nodes with text or an image.
+        origin_nodes = [n for n in vector_result.nodes if _node_has_renderable_content(n)]
+        if not origin_nodes:
+            return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
+        if len(origin_nodes) == 1:
+            only = origin_nodes[0]
+            return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[1.0])
+
         documents = _node_documents_with_images(origin_nodes)
 
         rerank_results = await self.rerank(

--- a/backend/rag/rerank/multimodal_dashscope_reranker.py
+++ b/backend/rag/rerank/multimodal_dashscope_reranker.py
@@ -234,14 +234,17 @@ class MultimodalDashscopeReranker:
         if not vector_result.nodes or len(vector_result.nodes) <= 1:
             return vector_result
 
-        # Rerank API rejects empty documents; keep only nodes with text or an image.
-        origin_nodes = [n for n in vector_result.nodes if _node_has_renderable_content(n)]
-        if not origin_nodes:
+        # Rerank API rejects empty documents; keep only nodes with text or an image
+        # while preserving each survivor's original similarity.
+        sims = vector_result.similarities or [0.0] * len(vector_result.nodes)
+        kept = [(n, s) for n, s in zip(vector_result.nodes, sims) if _node_has_renderable_content(n)]
+        if not kept:
             return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
-        if len(origin_nodes) == 1:
-            only = origin_nodes[0]
-            return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[1.0])
+        if len(kept) == 1:
+            only, sim = kept[0]
+            return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[sim])
 
+        origin_nodes = [n for n, _ in kept]
         documents = _node_documents_with_images(origin_nodes)
 
         rerank_results = await self.rerank(

--- a/backend/rag/rerank/multimodal_dashscope_reranker.py
+++ b/backend/rag/rerank/multimodal_dashscope_reranker.py
@@ -231,17 +231,18 @@ class MultimodalDashscopeReranker:
             raise ValueError("Query content cannot be empty")
         if not vector_result:
             raise ValueError("VectorStoreQueryResult list cannot be empty")
-        if not vector_result.nodes or len(vector_result.nodes) <= 1:
-            return vector_result
-
         # Rerank API rejects empty documents; keep only nodes with text or an image
-        # while preserving each survivor's original similarity.
-        sims = vector_result.similarities or [0.0] * len(vector_result.nodes)
-        kept = [(n, s) for n, s in zip(vector_result.nodes, sims) if _node_has_renderable_content(n)]
+        # while preserving each survivor's original similarity. Apply
+        # similarity_threshold to the sole survivor too.
+        nodes = vector_result.nodes or []
+        sims = vector_result.similarities or [0.0] * len(nodes)
+        kept = [(n, s) for n, s in zip(nodes, sims) if _node_has_renderable_content(n)]
         if not kept:
             return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
         if len(kept) == 1:
             only, sim = kept[0]
+            if sim < similarity_threshold:
+                return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
             return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[sim])
 
         origin_nodes = [n for n, _ in kept]

--- a/backend/rag/rerank/reranker.py
+++ b/backend/rag/rerank/reranker.py
@@ -222,7 +222,14 @@ class OpenAICompatibleReranker:
         if not vector_result.nodes or len(vector_result.nodes) <= 1:
             return vector_result
 
-        origin_nodes = vector_result.nodes
+        # Rerank APIs reject empty documents; drop empty-text nodes before the call.
+        origin_nodes = [n for n in vector_result.nodes if (n.text or "").strip()]
+        if not origin_nodes:
+            return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
+        if len(origin_nodes) == 1:
+            only = origin_nodes[0]
+            return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[1.0])
+
         documents=[node.text for node in origin_nodes]
         rerank_results = await self.rerank(query, documents, model, top_n, similarity_threshold)
 

--- a/backend/rag/rerank/reranker.py
+++ b/backend/rag/rerank/reranker.py
@@ -222,14 +222,17 @@ class OpenAICompatibleReranker:
         if not vector_result.nodes or len(vector_result.nodes) <= 1:
             return vector_result
 
-        # Rerank APIs reject empty documents; drop empty-text nodes before the call.
-        origin_nodes = [n for n in vector_result.nodes if (n.text or "").strip()]
-        if not origin_nodes:
+        # Rerank APIs reject empty documents; drop empty-text nodes before the call
+        # while preserving each survivor's original similarity.
+        sims = vector_result.similarities or [0.0] * len(vector_result.nodes)
+        kept = [(n, s) for n, s in zip(vector_result.nodes, sims) if (n.text or "").strip()]
+        if not kept:
             return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
-        if len(origin_nodes) == 1:
-            only = origin_nodes[0]
-            return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[1.0])
+        if len(kept) == 1:
+            only, sim = kept[0]
+            return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[sim])
 
+        origin_nodes = [n for n, _ in kept]
         documents=[node.text for node in origin_nodes]
         rerank_results = await self.rerank(query, documents, model, top_n, similarity_threshold)
 

--- a/backend/rag/rerank/reranker.py
+++ b/backend/rag/rerank/reranker.py
@@ -219,17 +219,18 @@ class OpenAICompatibleReranker:
         if not vector_result:
             raise ValueError("VectorStoreQueryResult list cannot be empty")
 
-        if not vector_result.nodes or len(vector_result.nodes) <= 1:
-            return vector_result
-
-        # Rerank APIs reject empty documents; drop empty-text nodes before the call
-        # while preserving each survivor's original similarity.
-        sims = vector_result.similarities or [0.0] * len(vector_result.nodes)
-        kept = [(n, s) for n, s in zip(vector_result.nodes, sims) if (n.text or "").strip()]
+        # Rerank APIs reject empty documents; drop empty-text nodes first while
+        # preserving each survivor's original similarity. Apply similarity_threshold
+        # to the sole survivor too — otherwise a low-score node bypasses the gate.
+        nodes = vector_result.nodes or []
+        sims = vector_result.similarities or [0.0] * len(nodes)
+        kept = [(n, s) for n, s in zip(nodes, sims) if (n.text or "").strip()]
         if not kept:
             return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
         if len(kept) == 1:
             only, sim = kept[0]
+            if sim < similarity_threshold:
+                return VectorStoreQueryResult(nodes=[], ids=[], similarities=[])
             return VectorStoreQueryResult(nodes=[only], ids=[only.node_id], similarities=[sim])
 
         origin_nodes = [n for n, _ in kept]

--- a/tests/rag/rerank/test_dashscope_rerank.py
+++ b/tests/rag/rerank/test_dashscope_rerank.py
@@ -83,7 +83,70 @@ async def test_dashscope_rerank(dashscope_reranker, sample_query, sample_documen
     assert scores == sorted(scores, reverse=True), "结果应该按相关性分数降序排列"
 
     top_doc_text = sample_documents[results[0].index]
-    second_doc_text = sample_documents[results[1].index] 
+    second_doc_text = sample_documents[results[1].index]
     assert top_doc_text == "数据库查询性能优化是提升应用响应速度的关键。可以通过创建合适的索引、优化SQL语句结构、使用查询缓存、分析执行计划等方式来提升查询效率。索引应该建立在经常用于WHERE、JOIN和ORDER BY的列上，但要避免过度索引。"
     assert second_doc_text == "SQL查询优化技巧包括：避免使用SELECT *，只查询需要的列；使用LIMIT限制返回结果数量；合理使用JOIN，避免笛卡尔积；在WHERE子句中使用索引列；避免在WHERE子句中使用函数，这会导致索引失效。"
 
+
+# ---------------------------------------------------------------------------
+# Unit tests (no real API): vector_store_rerank empty-text filtering
+# ---------------------------------------------------------------------------
+
+from unittest.mock import patch, AsyncMock
+from llama_index.core.schema import TextNode
+from llama_index.core.vector_stores.types import VectorStoreQueryResult
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_filters_empty_text_nodes():
+    """Empty-text nodes must not be sent to DashScope — API rejects them with 400."""
+    r = DashscopeReranker(api_key="sk")
+    n_empty = TextNode(id_="empty", text="")
+    n_keep1 = TextNode(id_="k1", text="real doc 1")
+    n_keep2 = TextNode(id_="k2", text="real doc 2")
+    vr = VectorStoreQueryResult(
+        nodes=[n_empty, n_keep1, n_keep2],
+        ids=["empty", "k1", "k2"],
+        similarities=[0.1, 0.2, 0.3],
+    )
+    fake_results = [
+        RerankResult(index=1, score=0.9, doc="real doc 2"),
+        RerankResult(index=0, score=0.7, doc="real doc 1"),
+    ]
+    with patch.object(r, "rerank", new=AsyncMock(return_value=fake_results)) as m:
+        out = await r.vector_store_rerank(query="q", vector_result=vr, top_n=2)
+        kwargs_or_args = m.await_args
+        # documents passed positionally as 2nd arg in current impl
+        sent_documents = kwargs_or_args.args[1] if len(kwargs_or_args.args) >= 2 else kwargs_or_args.kwargs.get("documents")
+        assert "" not in sent_documents
+        assert sent_documents == ["real doc 1", "real doc 2"]
+        assert out.ids == ["k2", "k1"]
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_all_empty_returns_empty_result():
+    r = DashscopeReranker(api_key="sk")
+    vr = VectorStoreQueryResult(
+        nodes=[TextNode(id_="a", text=""), TextNode(id_="b", text="   ")],
+        ids=["a", "b"],
+        similarities=[0.1, 0.2],
+    )
+    with patch.object(r, "rerank", new=AsyncMock()) as m:
+        out = await r.vector_store_rerank(query="q", vector_result=vr)
+        m.assert_not_called()
+    assert out.nodes == []
+    assert out.ids == []
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_single_nonempty_after_filter_skips_api():
+    r = DashscopeReranker(api_key="sk")
+    vr = VectorStoreQueryResult(
+        nodes=[TextNode(id_="a", text=""), TextNode(id_="b", text="only one")],
+        ids=["a", "b"],
+        similarities=[0.1, 0.2],
+    )
+    with patch.object(r, "rerank", new=AsyncMock()) as m:
+        out = await r.vector_store_rerank(query="q", vector_result=vr)
+        m.assert_not_called()
+    assert out.ids == ["b"]

--- a/tests/rag/rerank/test_dashscope_rerank.py
+++ b/tests/rag/rerank/test_dashscope_rerank.py
@@ -150,3 +150,26 @@ async def test_vector_store_rerank_single_nonempty_after_filter_skips_api():
         out = await r.vector_store_rerank(query="q", vector_result=vr)
         m.assert_not_called()
     assert out.ids == ["b"]
+    # Must preserve original similarity, not invent 1.0
+    assert out.similarities == [0.2]
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_single_survivor_preserves_low_score():
+    """Regression: an empty-text node with high score must not boost a surviving
+    low-score node to 1.0 (which would bypass downstream thresholds and inflate
+    multi-KB merge ordering)."""
+    r = DashscopeReranker(api_key="sk")
+    vr = VectorStoreQueryResult(
+        nodes=[
+            TextNode(id_="empty_high", text=""),
+            TextNode(id_="valid_low", text="real but low"),
+        ],
+        ids=["empty_high", "valid_low"],
+        similarities=[0.99, 0.05],
+    )
+    with patch.object(r, "rerank", new=AsyncMock()) as m:
+        out = await r.vector_store_rerank(query="q", vector_result=vr)
+        m.assert_not_called()
+    assert out.ids == ["valid_low"]
+    assert out.similarities == [0.05]

--- a/tests/rag/rerank/test_dashscope_rerank.py
+++ b/tests/rag/rerank/test_dashscope_rerank.py
@@ -173,3 +173,53 @@ async def test_vector_store_rerank_single_survivor_preserves_low_score():
         m.assert_not_called()
     assert out.ids == ["valid_low"]
     assert out.similarities == [0.05]
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_single_empty_node_returns_empty():
+    """Single empty-text input must NOT pass through unchanged (pre-filter must run)."""
+    r = DashscopeReranker(api_key="sk")
+    vr = VectorStoreQueryResult(
+        nodes=[TextNode(id_="x", text="")], ids=["x"], similarities=[0.99]
+    )
+    with patch.object(r, "rerank", new=AsyncMock()) as m:
+        out = await r.vector_store_rerank(query="q", vector_result=vr)
+        m.assert_not_called()
+    assert out.nodes == []
+    assert out.similarities == []
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_single_survivor_below_threshold_drops():
+    """Sole survivor with score below similarity_threshold must be dropped."""
+    r = DashscopeReranker(api_key="sk")
+    vr = VectorStoreQueryResult(
+        nodes=[
+            TextNode(id_="bad", text=""),
+            TextNode(id_="low", text="below threshold"),
+        ],
+        ids=["bad", "low"],
+        similarities=[0.99, 0.05],
+    )
+    with patch.object(r, "rerank", new=AsyncMock()) as m:
+        out = await r.vector_store_rerank(
+            query="q", vector_result=vr, similarity_threshold=0.8
+        )
+        m.assert_not_called()
+    assert out.nodes == []
+    assert out.similarities == []
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_single_input_node_below_threshold_drops():
+    """Single non-empty input below threshold must be dropped (no pre-filter bypass)."""
+    r = DashscopeReranker(api_key="sk")
+    vr = VectorStoreQueryResult(
+        nodes=[TextNode(id_="x", text="valid")], ids=["x"], similarities=[0.05]
+    )
+    with patch.object(r, "rerank", new=AsyncMock()) as m:
+        out = await r.vector_store_rerank(
+            query="q", vector_result=vr, similarity_threshold=0.8
+        )
+        m.assert_not_called()
+    assert out.nodes == []

--- a/tests/rag/rerank/test_fusion_reranker.py
+++ b/tests/rag/rerank/test_fusion_reranker.py
@@ -122,6 +122,28 @@ class TestMergeVectorStoreResultsByText:
         result = merge_vector_store_results_by_text(r1, r2)
         assert len(result.nodes) == 0
 
+    def test_skips_empty_text_nodes(self):
+        n_empty = TextNode(id_="a", text="")
+        n_keep = TextNode(id_="b", text="real content")
+        r1 = _make_result([n_empty, n_keep], [0.9, 0.8])
+        r2 = _make_result([], [])
+        result = merge_vector_store_results_by_text(r1, r2)
+        assert result.ids == ["b"]
+
+    def test_skips_whitespace_only_text_nodes(self):
+        n_ws = TextNode(id_="a", text="   \n\t  ")
+        n_keep = TextNode(id_="b", text="real content")
+        r1 = _make_result([n_ws], [0.9])
+        r2 = _make_result([n_keep], [0.8])
+        result = merge_vector_store_results_by_text(r1, r2)
+        assert result.ids == ["b"]
+
+    def test_all_empty_text_returns_empty(self):
+        r1 = _make_result([TextNode(id_="a", text="")], [0.9])
+        r2 = _make_result([TextNode(id_="b", text="  ")], [0.8])
+        result = merge_vector_store_results_by_text(r1, r2)
+        assert len(result.nodes) == 0
+
 
 class TestFilterNodeResult:
     def test_threshold_filter_and_sort(self):

--- a/tests/rag/rerank/test_multimodal_dashscope_rerank.py
+++ b/tests/rag/rerank/test_multimodal_dashscope_rerank.py
@@ -7,6 +7,7 @@ from llama_index.core.vector_stores.types import VectorStoreQueryResult
 from rag.rerank.multimodal_dashscope_reranker import (
     MultimodalDashscopeReranker,
     _node_documents_with_images,
+    _node_has_renderable_content,
 )
 from rag.rerank.reranker import RerankResult
 
@@ -153,3 +154,50 @@ async def test_vector_store_rerank_uses_node_images():
         assert out.similarities == [0.9, 0.7]
         kwargs = m.await_args.kwargs
         assert kwargs["documents"] == [{"text": "text doc"}, {"image": "http://x/a.png"}]
+
+
+def test_node_has_renderable_content_text():
+    assert _node_has_renderable_content(TextNode(text="hi", metadata={}))
+
+
+def test_node_has_renderable_content_image_only():
+    n = TextNode(text="", metadata={"images_info": [{"url": "http://x/a.png"}]})
+    assert _node_has_renderable_content(n)
+
+
+def test_node_has_renderable_content_empty():
+    assert not _node_has_renderable_content(TextNode(text="   ", metadata={}))
+    assert not _node_has_renderable_content(
+        TextNode(text="", metadata={"images_info": [{"desc": "no url"}]})
+    )
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_drops_text_empty_no_image_nodes():
+    r = MultimodalDashscopeReranker(api_key="sk")
+    n_bad = TextNode(id_="bad", text="", metadata={"images_info": []})
+    n_text = TextNode(id_="t", text="real text", metadata={})
+    n_img = TextNode(
+        id_="i",
+        text="",
+        metadata={"images_info": [{"url": "http://x/y.png"}]},
+    )
+    vr = VectorStoreQueryResult(
+        nodes=[n_bad, n_text, n_img],
+        ids=["bad", "t", "i"],
+        similarities=[0.1, 0.2, 0.3],
+    )
+    fake_results = [
+        RerankResult(index=0, score=0.9, doc="real text"),
+        RerankResult(index=1, score=0.8, doc="http://x/y.png"),
+    ]
+    with patch.object(r, "rerank", new=AsyncMock(return_value=fake_results)) as m:
+        out = await r.vector_store_rerank(query="q", vector_result=vr, top_n=3)
+        kwargs = m.await_args.kwargs
+        # n_bad must be filtered out before API call
+        assert kwargs["documents"] == [
+            {"text": "real text"},
+            {"image": "http://x/y.png"},
+        ]
+        assert "bad" not in out.ids
+        assert out.ids == ["t", "i"]

--- a/tests/rag/rerank/test_multimodal_dashscope_rerank.py
+++ b/tests/rag/rerank/test_multimodal_dashscope_rerank.py
@@ -125,11 +125,43 @@ async def test_rerank_normalizes_string_query_and_documents():
 @pytest.mark.asyncio
 async def test_vector_store_rerank_passthrough_on_few_nodes():
     r = MultimodalDashscopeReranker(api_key="sk")
-    # 0 or 1 node short-circuits without API call
-    n = TextNode(text="solo", metadata={})
+    # 1 valid node short-circuits without API call and keeps its similarity
+    n = TextNode(id_="x", text="solo", metadata={})
     vr = VectorStoreQueryResult(nodes=[n], ids=["x"], similarities=[0.5])
-    result = await r.vector_store_rerank(query="q", vector_result=vr)
-    assert result is vr
+    with patch.object(r, "rerank", new=AsyncMock()) as m:
+        result = await r.vector_store_rerank(query="q", vector_result=vr)
+        m.assert_not_called()
+    assert result.ids == ["x"]
+    assert result.similarities == [0.5]
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_single_empty_node_returns_empty():
+    """A single empty-text node must not pass through unchanged."""
+    r = MultimodalDashscopeReranker(api_key="sk")
+    n = TextNode(id_="x", text="", metadata={})
+    vr = VectorStoreQueryResult(nodes=[n], ids=["x"], similarities=[0.99])
+    with patch.object(r, "rerank", new=AsyncMock()) as m:
+        result = await r.vector_store_rerank(query="q", vector_result=vr)
+        m.assert_not_called()
+    assert result.nodes == []
+    assert result.similarities == []
+
+
+@pytest.mark.asyncio
+async def test_vector_store_rerank_single_survivor_below_threshold_drops():
+    r = MultimodalDashscopeReranker(api_key="sk")
+    n_bad = TextNode(id_="bad", text="", metadata={})
+    n_low = TextNode(id_="low", text="below threshold", metadata={})
+    vr = VectorStoreQueryResult(
+        nodes=[n_bad, n_low], ids=["bad", "low"], similarities=[0.99, 0.05]
+    )
+    with patch.object(r, "rerank", new=AsyncMock()) as m:
+        result = await r.vector_store_rerank(
+            query="q", vector_result=vr, similarity_threshold=0.8
+        )
+        m.assert_not_called()
+    assert result.nodes == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
DashScope rerank API rejects requests where any document is an empty string ("text input should not be empty.: input.documents"). Nodes indexed with empty content (image-only chunks, whitespace-only chunks) were slipping through retrieval and triggering 400s.

Filter at both layers:
- merge_vector_store_results_by_text skips empty/whitespace text nodes
- vector_store_rerank in DashscopeReranker / OpenAICompatibleReranker filters empty-text nodes before building the documents payload
- MultimodalDashscopeReranker keeps image-only nodes, drops nodes with neither text nor image URL