### PR TITLE
fix(ui): make long model edit dialogs scrollable

### DIFF
--- a/frontend/app/config/model/embedding/modelDialog.tsx
+++ b/frontend/app/config/model/embedding/modelDialog.tsx
@@ -142,7 +142,7 @@ export const EmbeddingModelDialog: FC<EmbeddingModelDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogClose}>
-      <DialogContent className="sm:max-w-[640px]">
+      <DialogContent className="sm:max-w-[640px] flex flex-col max-h-[90vh]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <span className="type-corner-badge type-embedding">EMB</span>
@@ -153,7 +153,7 @@ export const EmbeddingModelDialog: FC<EmbeddingModelDialogProps> = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
+        <div className="space-y-4 py-2 flex-1 min-h-0 overflow-y-auto -mx-6 px-6">
           <div className="model-field-guide">
             <div>
               <span className="guide-label">模型服务需要</span>

--- a/frontend/app/config/model/llm/modelDialog.tsx
+++ b/frontend/app/config/model/llm/modelDialog.tsx
@@ -110,7 +110,7 @@ export const LLMModelDialog: FC<LLMModelDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogClose}>
-      <DialogContent className="sm:max-w-[640px]">
+      <DialogContent className="sm:max-w-[640px] flex flex-col max-h-[90vh]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <span className="type-corner-badge type-llm">LLM</span>
@@ -121,7 +121,7 @@ export const LLMModelDialog: FC<LLMModelDialogProps> = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
+        <div className="space-y-4 py-2 flex-1 min-h-0 overflow-y-auto -mx-6 px-6">
           <div className="model-field-guide">
             <div>
               <span className="guide-label">服务商需要</span>

--- a/frontend/app/config/model/reranker/modelDialog.tsx
+++ b/frontend/app/config/model/reranker/modelDialog.tsx
@@ -144,7 +144,7 @@ export const RerankerModelDialog: FC<RerankerModelDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleDialogClose}>
-      <DialogContent className="sm:max-w-[640px]">
+      <DialogContent className="sm:max-w-[640px] flex flex-col max-h-[90vh]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <span className="type-corner-badge type-reranker">RNK</span>
@@ -155,7 +155,7 @@ export const RerankerModelDialog: FC<RerankerModelDialogProps> = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
+        <div className="space-y-4 py-2 flex-1 min-h-0 overflow-y-auto -mx-6 px-6">
           <div className="model-field-guide">
             <div>
               <span className="guide-label">模型服务需要</span>


### PR DESCRIPTION
The LLM / Reranker / Embedding model edit dialogs grew taller than the viewport, pushing the Save button off-screen with no way to scroll. Cap the dialog at 90vh, switch its layout to a vertical flex column, and let the form body take the remaining space with overflow-y-auto so the header and footer stay pinned while the form scrolls.