### PR TITLE
ci(hotfix): run hotfix workflow on self-hosted runner

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -17,7 +17,7 @@ env:
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,15 +28,6 @@ jobs:
 
       - name: Check disk space
         run: df . -h
-  
-      - name: Free disk space
-        run: |
-          sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
-          sudo rm -rf \
-            /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-            /usr/lib/jvm || true
-          df . -h
 
       - name: Extract version
         run: |


### PR DESCRIPTION
## Summary
- Switch .github/workflows/hotfix.yml build job from ubuntu-latest to self-hosted so hotfix images build on the internal runner.
- Remove the Ubuntu-specific "Free disk space" step (sudo rm -rf /usr/share/dotnet /opt/ghc ...) since those paths do not exist on the self-hosted machine and it may not allow sudo. The trailing `docker image prune --filter "until=168h" --force -a` still handles cleanup.

## Test plan
- [ ] Trigger `Release Hotfix image` workflow via workflow_dispatch with a test hotfix_tag and confirm it runs on the self-hosted runner.
- [ ] Verify the image is pushed to both ${{ secrets.BUILD_ACR_URL }}/mybigpai/pairag and registry.cn-hangzhou.aliyuncs.com/mybigpai/pai-rag.
- [ ] Confirm disk usage on the self-hosted runner remains healthy after the run.