### PR TITLE
fix(chat): reduce intermittent 499s on /v1/chat/completions

### DIFF
--- a/src/pairag/api/middleware.py
+++ b/src/pairag/api/middleware.py
@@ -1,37 +1,75 @@
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi import FastAPI, Request
-from starlette.middleware.base import BaseHTTPMiddleware
+from fastapi import FastAPI
 from asgi_correlation_id import CorrelationIdMiddleware
 import time
 from loguru import logger
 
 
-class CustomMiddleWare(BaseHTTPMiddleware):
+class CustomMiddleWare:
+    """Pure ASGI middleware for request timing / logging.
+
+    The previous implementation extended Starlette's ``BaseHTTPMiddleware``,
+    which buffers the response body through an anyio memory stream. That
+    interfered with Server-Sent Events on ``/v1/chat/completions``: first
+    tokens were held back until the full stream finished, and
+    ``CancelledError`` raised on client disconnect was swallowed, leaving
+    upstream LLM connections open. Both symptoms lead to intermittent 499s
+    behind nginx / ALB.
+
+    Implementing the raw ASGI interface lets us wrap ``send`` and only touch
+    the ``http.response.start`` headers, so streaming chunks pass through
+    untouched and cancellations propagate to the SSE generator naturally.
+    """
+
     def __init__(self, app):
-        super().__init__(app)
-        self.last_log_time = 0
+        self.app = app
+        self.last_log_time = 0.0
         self.log_interval = 60  # seconds
 
-    async def dispatch(self, request: Request, call_next):
-        start_time = time.time()
-        response = await call_next(request)
-        process_time = time.time() - start_time
-        host = request.client.host or "unknown"
-        response.headers["X-Process-Time"] = str(process_time)
-        response.headers["X-Client-IP"] = host
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
 
-        if "get_upload_state" in str(request.url):
-            current_time = time.time()
-            if current_time - self.last_log_time >= self.log_interval:
-                logger.info(
-                    f"Request: {request.method} {request.url} - Response Time: {process_time:.4f} seconds Host {host}"
+        start_time = time.time()
+        client = scope.get("client")
+        host = client[0] if client else "unknown"
+
+        method = scope.get("method", "")
+        path = scope.get("path", "")
+        query_string = scope.get("query_string", b"")
+        if query_string:
+            try:
+                path = f"{path}?{query_string.decode('latin-1')}"
+            except Exception:
+                pass
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                process_time = time.time() - start_time
+                headers = list(message.get("headers", []))
+                headers.append(
+                    (b"x-process-time", f"{process_time:.4f}".encode("latin-1"))
                 )
-                self.last_log_time = current_time
-        else:
-            logger.info(
-                f"Request: {request.method} {request.url} - Response Time: {process_time:.4f} seconds Host {host}"
+                headers.append((b"x-client-ip", host.encode("latin-1")))
+                message["headers"] = headers
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            process_time = time.time() - start_time
+            log_line = (
+                f"Request: {method} {path} - Response Time: {process_time:.4f} "
+                f"seconds Host {host}"
             )
-        return response
+            if "get_upload_state" in path:
+                current_time = time.time()
+                if current_time - self.last_log_time >= self.log_interval:
+                    logger.info(log_line)
+                    self.last_log_time = current_time
+            else:
+                logger.info(log_line)
 
 
 def _configure_session_middleware(app):

--- a/src/pairag/chat/chat_flow.py
+++ b/src/pairag/chat/chat_flow.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from typing import (
     Any,
@@ -76,6 +77,15 @@ dispatcher = instrument.get_dispatcher(__name__)
 DEFAULT_GUARDRAIL_RESPONSE = "抱歉，无法处理这个请求。"
 DEFAULT_EMPTY_RESPONSE = "看起来你发了一条空白消息，有什么能帮到你的吗？"
 DEFAULT_ERROR_RESPONSE = "抱歉，系统出错，暂时无法处理这个请求。"
+
+# Wall-clock budgets for the steps that run BEFORE the first SSE byte is
+# flushed. If any of these dependencies hang, the client (behind nginx/ALB)
+# will hit its read timeout and the request shows up as an intermittent 499.
+# On timeout we degrade instead of blocking indefinitely, and always log so
+# ops can spot the slow upstream.
+INTENT_TIMEOUT_S = 8.0
+GUARDRAIL_TIMEOUT_S = 3.0
+RETRIEVAL_TIMEOUT_S = 10.0
 
 
 class ChatFlow:
@@ -392,12 +402,24 @@ class ChatFlow:
         postprocessor = resolve_postprocessor_from_retrieval_settings(
             retrieval_settings=_retrieval_settings
         )
-        nodes = await retriever.aretrieve(query_str)
+        try:
+            async def _run_retrieval() -> List[NodeWithScore]:
+                nodes = await retriever.aretrieve(query_str)
+                return await postprocessor.apostprocess_nodes(
+                    nodes,
+                    query_str=query_str,
+                )
 
-        reranked_nodes = await postprocessor.apostprocess_nodes(
-            nodes,
-            query_str=query_str,
-        )
+            reranked_nodes = await asyncio.wait_for(
+                _run_retrieval(), timeout=RETRIEVAL_TIMEOUT_S
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Retrieval timed out after {RETRIEVAL_TIMEOUT_S}s for "
+                f"knowledgebase={knowledgebase_name!r}, query={query_str!r}. "
+                f"Returning empty nodes."
+            )
+            reranked_nodes = []
         return reranked_nodes
 
     async def _achat_internal(
@@ -422,15 +444,32 @@ class ChatFlow:
 
         original_user_message = chat_request.messages[-1].content
         llm_kwargs = self._get_llm_kwargs(chat_request=chat_request)
-        if chat_request.intent is None:
-            # 意图识别
-            intent_result = await self._recognize_intent(
-                chat_request, chat_history_str=chat_history_str
+        try:
+            if chat_request.intent is None:
+                # 意图识别
+                intent_result = await asyncio.wait_for(
+                    self._recognize_intent(
+                        chat_request, chat_history_str=chat_history_str
+                    ),
+                    timeout=INTENT_TIMEOUT_S,
+                )
+            else:
+                # 直接改写
+                intent_result = await asyncio.wait_for(
+                    self._rewrite_query(
+                        chat_request, chat_history_str=chat_history_str
+                    ),
+                    timeout=INTENT_TIMEOUT_S,
+                )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"[{chat_id}] Intent recognition timed out after "
+                f"{INTENT_TIMEOUT_S}s, falling back to CHAT_LLM. "
+                f"query={original_user_message!r}"
             )
-        else:
-            # 直接改写
-            intent_result = await self._rewrite_query(
-                chat_request, chat_history_str=chat_history_str
+            intent_result = IntentResult(
+                intent=ChatIntentType.CHAT_LLM,
+                query_str=original_user_message,
             )
 
         logger.info(
@@ -440,15 +479,28 @@ class ChatFlow:
         # 安全护栏
         guardrail = resolve_llm_guardrail(self.config)
         if guardrail is not None:
-            check_result = await guardrail.acheck(text=original_user_message)
-            if check_result.reject:
+            try:
+                check_result = await asyncio.wait_for(
+                    guardrail.acheck(text=original_user_message),
+                    timeout=GUARDRAIL_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"[{chat_id}] Guardrail check timed out after "
+                    f"{GUARDRAIL_TIMEOUT_S}s, treating as passed. "
+                    f"query={original_user_message!r}"
+                )
+                check_result = None
+
+            if check_result is not None and check_result.reject:
                 logger.info(f"Guadrail check failed: {original_user_message}.")
                 if chat_request.stream:
                     return response_gen_from_text(check_result.advice)
                 else:
                     return response_from_text(check_result.advice)
 
-            logger.info(f"Guadrail check passed: {original_user_message}.")
+            if check_result is not None:
+                logger.info(f"Guadrail check passed: {original_user_message}.")
 
         # 意图分发
         logger.info(f"Routing query {original_user_message} to {intent_result.intent}")

--- a/src/pairag/chat/utils/chat_utils.py
+++ b/src/pairag/chat/utils/chat_utils.py
@@ -306,25 +306,42 @@ async def make_completion_chunk_response(
     except asyncio.CancelledError:
         logger.warning(f"Streaming cancelled: {full_content}")
         raise
+    except (BrokenPipeError, ConnectionError) as e:
+        # Client already went away; do not attempt another yield.
+        logger.warning(f"Streaming aborted, client disconnected: {e}")
+        raise
     except Exception:
         logger.error(f"Streaming failed: {traceback.format_exc()}")
-        chunk = ChatCompletionChunk(
-            id=chat_id,
-            created=created_ts,
-            model=model,
-            choices=[
-                chat_completion_chunk.Choice(
-                    index=chunk_id,
-                    delta=chat_completion_chunk.ChoiceDelta(
-                        role=MessageRole.ASSISTANT.value,
-                        content=DEFAULT_ERROR_RESPONSE,
-                    ),
-                    finish_reason="stop",
-                )
-            ],
-            object="chat.completion.chunk",
-        )
-        yield _make_json_chunk(data=chunk.model_dump(mode="json"))
+        try:
+            chunk = ChatCompletionChunk(
+                id=chat_id,
+                created=created_ts,
+                model=model,
+                choices=[
+                    chat_completion_chunk.Choice(
+                        index=chunk_id,
+                        delta=chat_completion_chunk.ChoiceDelta(
+                            role=MessageRole.ASSISTANT.value,
+                            content=DEFAULT_ERROR_RESPONSE,
+                        ),
+                        finish_reason="stop",
+                    )
+                ],
+                object="chat.completion.chunk",
+            )
+            yield _make_json_chunk(data=chunk.model_dump(mode="json"))
+        except (BrokenPipeError, ConnectionError, asyncio.CancelledError) as e:
+            # Writing the fallback chunk failed because the peer is gone.
+            # Swallow the secondary error so the original traceback above is
+            # what surfaces in logs; the outer generator machinery will
+            # propagate as needed.
+            logger.warning(
+                f"Failed to deliver error chunk, client disconnected: {e}"
+            )
+        except Exception:
+            logger.error(
+                f"Failed to deliver error chunk: {traceback.format_exc()}"
+            )
 
         raise
 

--- a/src/pairag/integrations/llms/pai/pai_llm.py
+++ b/src/pairag/integrations/llms/pai/pai_llm.py
@@ -197,69 +197,141 @@ class PaiLlm(OpenAILike):
             response_content = ""
             think_tag_added = False
 
-            async for response in completion_response_gen:
-                if is_enable_thinking:
-                    # 尝试从raw对象中获取reasoning_content
-                    reasoning_text = ""
-                    if hasattr(response, "raw") and response.raw:
-                        # raw是ChatCompletionChunk对象
-                        if hasattr(response.raw, "choices") and response.raw.choices:
-                            delta = (
-                                response.raw.choices[0].delta
-                                if response.raw.choices
-                                else None
-                            )
-                            if delta and hasattr(delta, "reasoning_content"):
-                                reasoning_text = delta.reasoning_content or ""
+            try:
+                async for response in completion_response_gen:
+                    if is_enable_thinking:
+                        # 尝试从raw对象中获取reasoning_content
+                        reasoning_text = ""
+                        if hasattr(response, "raw") and response.raw:
+                            # raw是ChatCompletionChunk对象
+                            if hasattr(response.raw, "choices") and response.raw.choices:
+                                delta = (
+                                    response.raw.choices[0].delta
+                                    if response.raw.choices
+                                    else None
+                                )
+                                if delta and hasattr(delta, "reasoning_content"):
+                                    reasoning_text = delta.reasoning_content or ""
 
-                    # 如果有reasoning_content，处理它
-                    if reasoning_text:
-                        if not think_tag_added:
-                            # 第一次遇到reasoning_content，输出<think>标签
+                        # 如果有reasoning_content，处理它
+                        if reasoning_text:
+                            if not think_tag_added:
+                                # 第一次遇到reasoning_content，输出<think>标签
+                                yield ChatResponse(
+                                    message=ChatMessage(
+                                        role=MessageRole.ASSISTANT,
+                                        content="<think>",
+                                        additional_kwargs=response.additional_kwargs,
+                                    ),
+                                    delta="<think>",
+                                    raw="<think>",
+                                )
+                                yield ChatResponse(
+                                    message=ChatMessage(
+                                        role=MessageRole.ASSISTANT,
+                                        content="<think>\n",
+                                        additional_kwargs=response.additional_kwargs,
+                                    ),
+                                    delta="\n",
+                                    raw="\n",
+                                )
+                                response_content = "<think>\n"
+                                think_tag_added = True
+                                in_reasoning = True
+
+                            # 输出reasoning_content内容（每个片段都要输出）
+                            response_content += reasoning_text
                             yield ChatResponse(
                                 message=ChatMessage(
                                     role=MessageRole.ASSISTANT,
-                                    content="<think>",
+                                    content=response_content,
                                     additional_kwargs=response.additional_kwargs,
                                 ),
-                                delta="<think>",
-                                raw="<think>",
+                                delta=reasoning_text,
+                                raw=response.raw,
+                            )
+                            # 继续下一个循环，不处理delta
+                            continue
+
+                        # 检查reasoning是否结束（通过delta内容判断）
+                        if in_reasoning and not reasoning_ended and response.delta:
+                            # 如果有delta内容且之前在reasoning中，说明reasoning结束了
+                            yield ChatResponse(
+                                message=ChatMessage(
+                                    role=MessageRole.ASSISTANT,
+                                    content=response_content + "\n</think>",
+                                    additional_kwargs=response.additional_kwargs,
+                                ),
+                                delta="\n</think>",
+                                raw="\n</think>",
                             )
                             yield ChatResponse(
                                 message=ChatMessage(
                                     role=MessageRole.ASSISTANT,
-                                    content="<think>\n",
+                                    content=response_content + "\n</think>\n\n",
                                     additional_kwargs=response.additional_kwargs,
                                 ),
-                                delta="\n",
-                                raw="\n",
+                                delta="\n\n",
+                                raw="\n\n",
                             )
-                            response_content = "<think>\n"
-                            think_tag_added = True
-                            in_reasoning = True
+                            response_content += "\n</think>\n\n"
+                            reasoning_ended = True
+                            in_reasoning = False
 
-                        # 输出reasoning_content内容（每个片段都要输出）
-                        response_content += reasoning_text
-                        yield ChatResponse(
-                            message=ChatMessage(
-                                role=MessageRole.ASSISTANT,
-                                content=response_content,
-                                additional_kwargs=response.additional_kwargs,
-                            ),
-                            delta=reasoning_text,
-                            raw=response.raw,
-                        )
-                        # 继续下一个循环，不处理delta
-                        continue
+                        # 处理第一个chunk，如果没有reasoning_content但需要添加<think>
+                        if is_first_chunk and response.delta:
+                            if not think_tag_added and not response.text.startswith(
+                                "<think>"
+                            ):
+                                # 没有reasoning_content，但需要补充<think>
+                                yield ChatResponse(
+                                    message=ChatMessage(
+                                        role=MessageRole.ASSISTANT,
+                                        content="<think>",
+                                        additional_kwargs=response.additional_kwargs,
+                                    ),
+                                    delta="<think>",
+                                    raw="<think>",
+                                )
+                                yield ChatResponse(
+                                    message=ChatMessage(
+                                        role=MessageRole.ASSISTANT,
+                                        content="<think>\n",
+                                        additional_kwargs=response.additional_kwargs,
+                                    ),
+                                    delta="\n",
+                                    raw="\n",
+                                )
+                                response_content = "<think>\n"
+                                think_tag_added = True
+                            is_first_chunk = False
 
-                    # 检查reasoning是否结束（通过delta内容判断）
-                    if in_reasoning and not reasoning_ended and response.delta:
-                        # 如果有delta内容且之前在reasoning中，说明reasoning结束了
+                    # 输出正常的delta内容
+                    response_content += response.delta
+                    yield ChatResponse(
+                        message=ChatMessage(
+                            role=MessageRole.ASSISTANT,
+                            content=response_content,
+                            additional_kwargs=response.additional_kwargs,
+                        ),
+                        delta=response.delta,
+                        raw=response.raw,
+                        additional_kwargs=response.additional_kwargs,
+                    )
+            finally:
+                # 若上游只发送了 reasoning_content 就结束（或异常中断），
+                # 必须补一个 </think> 关闭标签，避免下游客户端看到未闭合
+                # 的 <think> 卡住或解析失败，从而更早断开连接。
+                if in_reasoning and not reasoning_ended:
+                    logger.warning(
+                        "Reasoning stream ended without a trailing delta; "
+                        "emitting synthetic </think> to close the block."
+                    )
+                    try:
                         yield ChatResponse(
                             message=ChatMessage(
                                 role=MessageRole.ASSISTANT,
                                 content=response_content + "\n</think>",
-                                additional_kwargs=response.additional_kwargs,
                             ),
                             delta="\n</think>",
                             raw="\n</think>",
@@ -268,55 +340,14 @@ class PaiLlm(OpenAILike):
                             message=ChatMessage(
                                 role=MessageRole.ASSISTANT,
                                 content=response_content + "\n</think>\n\n",
-                                additional_kwargs=response.additional_kwargs,
                             ),
                             delta="\n\n",
                             raw="\n\n",
                         )
-                        response_content += "\n</think>\n\n"
-                        reasoning_ended = True
-                        in_reasoning = False
-
-                    # 处理第一个chunk，如果没有reasoning_content但需要添加<think>
-                    if is_first_chunk and response.delta:
-                        if not think_tag_added and not response.text.startswith(
-                            "<think>"
-                        ):
-                            # 没有reasoning_content，但需要补充<think>
-                            yield ChatResponse(
-                                message=ChatMessage(
-                                    role=MessageRole.ASSISTANT,
-                                    content="<think>",
-                                    additional_kwargs=response.additional_kwargs,
-                                ),
-                                delta="<think>",
-                                raw="<think>",
-                            )
-                            yield ChatResponse(
-                                message=ChatMessage(
-                                    role=MessageRole.ASSISTANT,
-                                    content="<think>\n",
-                                    additional_kwargs=response.additional_kwargs,
-                                ),
-                                delta="\n",
-                                raw="\n",
-                            )
-                            response_content = "<think>\n"
-                            think_tag_added = True
-                        is_first_chunk = False
-
-                # 输出正常的delta内容
-                response_content += response.delta
-                yield ChatResponse(
-                    message=ChatMessage(
-                        role=MessageRole.ASSISTANT,
-                        content=response_content,
-                        additional_kwargs=response.additional_kwargs,
-                    ),
-                    delta=response.delta,
-                    raw=response.raw,
-                    additional_kwargs=response.additional_kwargs,
-                )
+                    except Exception:
+                        # Consumer already gone / generator being closed —
+                        # nothing meaningful we can do here.
+                        pass
 
         return gen()
 
@@ -346,111 +377,139 @@ class PaiLlm(OpenAILike):
                 response_content = ""
                 think_tag_added = False
 
-                async for response in await self._llm.astream_chat(messages, **kwargs):
-                    # 尝试从raw对象中获取reasoning_content
-                    reasoning_text = ""
-                    if hasattr(response, "raw") and response.raw:
-                        # raw是ChatCompletionChunk对象
-                        if hasattr(response.raw, "choices") and response.raw.choices:
-                            delta = (
-                                response.raw.choices[0].delta
-                                if response.raw.choices
-                                else None
-                            )
-                            if delta and hasattr(delta, "reasoning_content"):
-                                reasoning_text = delta.reasoning_content or ""
+                try:
+                    async for response in await self._llm.astream_chat(messages, **kwargs):
+                        # 尝试从raw对象中获取reasoning_content
+                        reasoning_text = ""
+                        if hasattr(response, "raw") and response.raw:
+                            # raw是ChatCompletionChunk对象
+                            if hasattr(response.raw, "choices") and response.raw.choices:
+                                delta = (
+                                    response.raw.choices[0].delta
+                                    if response.raw.choices
+                                    else None
+                                )
+                                if delta and hasattr(delta, "reasoning_content"):
+                                    reasoning_text = delta.reasoning_content or ""
 
-                    # 如果有reasoning_content，处理它
-                    if reasoning_text:
-                        if not think_tag_added:
-                            # 第一次遇到reasoning_content，输出<think>标签
+                        # 如果有reasoning_content，处理它
+                        if reasoning_text:
+                            if not think_tag_added:
+                                # 第一次遇到reasoning_content，输出<think>标签
+                                yield ChatResponse(
+                                    message=ChatMessage(
+                                        role=MessageRole.ASSISTANT,
+                                        content="<think>",
+                                    ),
+                                    delta="<think>",
+                                )
+                                yield ChatResponse(
+                                    message=ChatMessage(
+                                        role=MessageRole.ASSISTANT,
+                                        content="<think>\n",
+                                    ),
+                                    delta="\n",
+                                )
+                                response_content = "<think>\n"
+                                think_tag_added = True
+                                in_reasoning = True
+
+                            # 输出reasoning_content内容（每个片段都要输出）
+                            response_content += reasoning_text
                             yield ChatResponse(
                                 message=ChatMessage(
                                     role=MessageRole.ASSISTANT,
-                                    content="<think>",
+                                    content=response_content,
+                                    additional_kwargs=response.additional_kwargs,
                                 ),
-                                delta="<think>",
+                                delta=reasoning_text,
+                                raw=response.raw,
+                            )
+                            # 继续下一个循环，不处理delta
+                            continue
+
+                        # 检查reasoning是否结束（通过delta内容判断）
+                        if in_reasoning and not reasoning_ended and response.delta:
+                            # 如果有delta内容且之前在reasoning中，说明reasoning结束了
+                            yield ChatResponse(
+                                message=ChatMessage(
+                                    role=MessageRole.ASSISTANT,
+                                    content=response_content + "\n</think>",
+                                ),
+                                delta="\n</think>",
                             )
                             yield ChatResponse(
                                 message=ChatMessage(
                                     role=MessageRole.ASSISTANT,
-                                    content="<think>\n",
+                                    content=response_content + "\n</think>\n\n",
                                 ),
-                                delta="\n",
+                                delta="\n\n",
                             )
-                            response_content = "<think>\n"
-                            think_tag_added = True
-                            in_reasoning = True
+                            response_content += "\n</think>\n\n"
+                            reasoning_ended = True
+                            in_reasoning = False
 
-                        # 输出reasoning_content内容（每个片段都要输出）
-                        response_content += reasoning_text
+                        # 处理第一个chunk，如果没有reasoning_content但需要添加<think>
+                        if is_first_chunk and response.delta:
+                            if not think_tag_added and not response.delta.startswith(
+                                "<think>"
+                            ):
+                                # 没有reasoning_content，但需要补充<think>
+                                yield ChatResponse(
+                                    message=ChatMessage(
+                                        role=MessageRole.ASSISTANT,
+                                        content="<think>",
+                                    ),
+                                    delta="<think>",
+                                )
+                                yield ChatResponse(
+                                    message=ChatMessage(
+                                        role=MessageRole.ASSISTANT,
+                                        content="<think>\n",
+                                    ),
+                                    delta="\n",
+                                )
+                                response_content = "<think>\n"
+                                think_tag_added = True
+                            is_first_chunk = False
+
+                        # 输出正常的delta内容
+                        response_content += response.delta
                         yield ChatResponse(
                             message=ChatMessage(
                                 role=MessageRole.ASSISTANT,
                                 content=response_content,
-                                additional_kwargs=response.additional_kwargs,
                             ),
-                            delta=reasoning_text,
-                            raw=response.raw,
+                            delta=response.delta,
+                            additional_kwargs=response.additional_kwargs,
                         )
-                        # 继续下一个循环，不处理delta
-                        continue
-
-                    # 检查reasoning是否结束（通过delta内容判断）
-                    if in_reasoning and not reasoning_ended and response.delta:
-                        # 如果有delta内容且之前在reasoning中，说明reasoning结束了
-                        yield ChatResponse(
-                            message=ChatMessage(
-                                role=MessageRole.ASSISTANT,
-                                content=response_content + "\n</think>",
-                            ),
-                            delta="\n</think>",
+                finally:
+                    # 若上游只发送了 reasoning_content 就结束（或异常中断），
+                    # 必须补一个 </think> 关闭标签，避免下游客户端看到未闭合
+                    # 的 <think> 卡住或解析失败，从而更早断开连接。
+                    if in_reasoning and not reasoning_ended:
+                        logger.warning(
+                            "Reasoning chat stream ended without a trailing "
+                            "delta; emitting synthetic </think> to close the "
+                            "block."
                         )
-                        yield ChatResponse(
-                            message=ChatMessage(
-                                role=MessageRole.ASSISTANT,
-                                content=response_content + "\n</think>\n\n",
-                            ),
-                            delta="\n\n",
-                        )
-                        response_content += "\n</think>\n\n"
-                        reasoning_ended = True
-                        in_reasoning = False
-
-                    # 处理第一个chunk，如果没有reasoning_content但需要添加<think>
-                    if is_first_chunk and response.delta:
-                        if not think_tag_added and not response.delta.startswith(
-                            "<think>"
-                        ):
-                            # 没有reasoning_content，但需要补充<think>
+                        try:
                             yield ChatResponse(
                                 message=ChatMessage(
                                     role=MessageRole.ASSISTANT,
-                                    content="<think>",
+                                    content=response_content + "\n</think>",
                                 ),
-                                delta="<think>",
+                                delta="\n</think>",
                             )
                             yield ChatResponse(
                                 message=ChatMessage(
                                     role=MessageRole.ASSISTANT,
-                                    content="<think>\n",
+                                    content=response_content + "\n</think>\n\n",
                                 ),
-                                delta="\n",
+                                delta="\n\n",
                             )
-                            response_content = "<think>\n"
-                            think_tag_added = True
-                        is_first_chunk = False
-
-                    # 输出正常的delta内容
-                    response_content += response.delta
-                    yield ChatResponse(
-                        message=ChatMessage(
-                            role=MessageRole.ASSISTANT,
-                            content=response_content,
-                        ),
-                        delta=response.delta,
-                        additional_kwargs=response.additional_kwargs,
-                    )
+                        except Exception:
+                            pass
 
         return gen()
 

--- a/src/pairag/integrations/trace/pai_query_wrapper.py
+++ b/src/pairag/integrations/trace/pai_query_wrapper.py
@@ -106,12 +106,27 @@ def pai_query_wrapper() -> Callable:
                                                     x
                                                 )
                                             )
-                                        full_content += chunk.choices[0].delta.content
+                                        # 尾包（usage-only）可能没有 choices，或
+                                        # delta.content 为 None，避免 IndexError /
+                                        # AttributeError 让整条 SSE 流中断。
+                                        if (
+                                            chunk.choices
+                                            and chunk.choices[0].delta
+                                            and chunk.choices[0].delta.content
+                                        ):
+                                            full_content += (
+                                                chunk.choices[0].delta.content
+                                            )
                                         if not end_time:
                                             end_time = time.time_ns()
-                                    except ValueError as e:
+                                    except (
+                                        ValueError,
+                                        IndexError,
+                                        AttributeError,
+                                        TypeError,
+                                    ) as e:
                                         logger.error(
-                                            "Invalid JSON or data structure:", e
+                                            f"Invalid JSON or data structure: {e}"
                                         )
                                     yield x
 
@@ -225,7 +240,20 @@ def pai_query_wrapper() -> Callable:
                 return f_return_val
 
         async def async_dummy_wrapper(_self: Any, *args: Any, **kwargs: Any) -> Any:
-            return await f(_self, *args, **kwargs)
+            f_return_val = await f(_self, *args, **kwargs)
+            if isinstance(f_return_val, AsyncGenerator):
+                # Wrap the generator with ``aclosing`` so the upstream
+                # httpx / LLM stream is torn down promptly if the client
+                # disconnects mid-stream. Without this, cancelled SSE
+                # requests can leave sockets hanging and slow subsequent
+                # requests — a known amplifier for intermittent 499s.
+                async def _wrapped() -> AsyncGenerator[Any, None]:
+                    async with contextlib.aclosing(f_return_val) as agen:
+                        async for x in agen:
+                            yield x
+
+                return _wrapped()
+            return f_return_val
 
         def dummy_wrapper(_self: Any, *args: Any, **kwargs: Any) -> Any:
             return f(_self, *args, **kwargs)


### PR DESCRIPTION
Customers reported occasional HTTP 499s (client closed connection) on the streaming chat endpoint. Investigation pointed to several places where the server could keep the client waiting past its read timeout, or fail to flush / close streams cleanly on disconnect. Fixes:

* api/middleware: rewrite CustomMiddleWare as a pure ASGI middleware. BaseHTTPMiddleware buffers SSE bodies via an anyio memory stream and swallows CancelledError, delaying first bytes and leaking upstream LLM streams after the client goes away. The pure ASGI version wraps send() and only touches http.response.start headers, letting chunks pass through untouched.

* chat/utils/chat_utils: harden the SSE error branch in make_completion_chunk_response. Explicitly bail on BrokenPipeError / ConnectionError, and wrap the fallback error-chunk yield in its own try/except so a dead client can't turn a first error into a second, noisier one.

* chat/chat_flow: add wall-clock timeouts + graceful degradation for the three steps that run BEFORE the first SSE byte (intent LLM, guardrail HTTP, retrieval + rerank). On timeout we log a warning and fall back: intent -> CHAT_LLM with the raw user message; guardrail -> pass; retrieval -> empty nodes. This keeps total pre-first-token budget under a typical 20-30s gateway read timeout.

* integrations/llms/pai/pai_llm: guarantee </think> is emitted even if the upstream reasoning model stops after sending only reasoning_content (or the stream is aborted mid-thought). Adds a try/finally that emits a synthetic </think>\\n\\n if we ever entered reasoning without closing it. Applied to both async_stream_completion_response_to_chat_response and async_chat_response_to_chat_response_with_think.

* integrations/trace/pai_query_wrapper: (a) usage-only tail chunks with empty choices no longer crash the SSE stream — chunk.choices[0].delta is now guarded and IndexError/AttributeError/TypeError are caught alongside ValueError; (b) the non-tracing async_dummy_wrapper now wraps returned async generators with contextlib.aclosing so the upstream LLM httpx stream is closed promptly on client disconnect, matching the behavior already applied in the tracing-enabled path.